### PR TITLE
[feat] 공통 예외 처리 및 응답 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/org/umc/travlocksserver/global/apiPayload/ApiResponse.java
+++ b/src/main/java/org/umc/travlocksserver/global/apiPayload/ApiResponse.java
@@ -1,0 +1,32 @@
+package org.umc.travlocksserver.global.apiPayload;
+
+import org.umc.travlocksserver.global.apiPayload.code.BaseCode;
+
+// ✨ 모든 API 응답을 일관된 JSON 구조로 반환하기 위한 레코드
+public record ApiResponse<T>(
+        boolean isSuccess,
+        String code,
+        String message,
+        T data
+) {
+
+    // ⚪ 성공 응답 (데이터 포함)
+    public static <T> ApiResponse<T> ok(BaseCode code, T data) {
+        return new ApiResponse<>(true, code.getCode(), code.getMessage(), data);
+    }
+
+    // ⚪ 성공 응답
+    public static <T> ApiResponse<T> ok(BaseCode code) {
+        return new ApiResponse<>(true, code.getCode(), code.getMessage(), null);
+    }
+
+    // ⚪ 실패 응답 (데이터 포함)
+    public static <T> ApiResponse<T> fail(BaseCode code, T data) {
+        return new ApiResponse<>(false, code.getCode(), code.getMessage(), data);
+    }
+
+    // ⚪ 실패 응답
+    public static <T> ApiResponse<T> fail(BaseCode code) {
+        return new ApiResponse<>(false, code.getCode(), code.getMessage(), null);
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/global/apiPayload/code/BaseCode.java
+++ b/src/main/java/org/umc/travlocksserver/global/apiPayload/code/BaseCode.java
@@ -1,0 +1,13 @@
+package org.umc.travlocksserver.global.apiPayload.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseCode {
+
+    HttpStatus getStatus();
+    String getMessage();
+
+    default String getCode() {
+        return ((Enum<?>) this).name();
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/global/apiPayload/code/common/CommonErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/global/apiPayload/code/common/CommonErrorCode.java
@@ -1,0 +1,34 @@
+package org.umc.travlocksserver.global.apiPayload.code.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.umc.travlocksserver.global.apiPayload.code.BaseCode;
+
+@Getter
+@AllArgsConstructor
+public enum CommonErrorCode implements BaseCode {
+
+    // 400
+    REQUEST_HEADER_EMPTY(HttpStatus.BAD_REQUEST, "요청 헤더가 비어있습니다."),
+    NOT_VALID_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 요청입니다."),
+    INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "요청 본문이 올바르지 않습니다."),
+    INVALID_VALUE(HttpStatus.BAD_REQUEST, "값이 비어있거나 유효하지 않습니다."),
+
+    // 404
+    NOT_FOUND_URL(HttpStatus.NOT_FOUND, "존재하지 않는 URL 입니다."),
+
+    // 405
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
+
+    //406
+    HTTP_MEDIA_TYPE_NOT_ACCEPTABLE(HttpStatus.NOT_ACCEPTABLE, "요청한 미디어 타입을 제공할 수 없습니다."),
+
+
+    // 500
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,  "서버 내부 오류가 발생했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/org/umc/travlocksserver/global/apiPayload/exception/GeneralException.java
+++ b/src/main/java/org/umc/travlocksserver/global/apiPayload/exception/GeneralException.java
@@ -1,0 +1,15 @@
+package org.umc.travlocksserver.global.apiPayload.exception;
+
+import lombok.Getter;
+import org.umc.travlocksserver.global.apiPayload.code.BaseCode;
+
+@Getter
+public abstract class GeneralException extends RuntimeException {
+
+    private final BaseCode errorCode;
+
+    public GeneralException(BaseCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/global/apiPayload/exception/MemberException.java
+++ b/src/main/java/org/umc/travlocksserver/global/apiPayload/exception/MemberException.java
@@ -1,0 +1,11 @@
+package org.umc.travlocksserver.global.apiPayload.exception;
+
+import org.umc.travlocksserver.global.apiPayload.code.common.CommonErrorCode;
+
+public class MemberException extends GeneralException {
+
+    // MemberErrorCode 생성하면 아래 CommonErrorCode -> MemberErrorCode로 변경
+    public MemberException(CommonErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/global/apiPayload/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/umc/travlocksserver/global/apiPayload/handler/GlobalExceptionHandler.java
@@ -43,9 +43,17 @@ public class GlobalExceptionHandler {
     }
 
     // ⚪ 지원하지 않는 HTTP 메서드 예외 처리
-    @ExceptionHandler({HttpRequestMethodNotSupportedException.class, MethodArgumentTypeMismatchException.class})
-    public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(Exception e) {
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
         BaseCode errorCode = CommonErrorCode.METHOD_NOT_ALLOWED;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+
+    // ⚪ 요청 파라미터 타입 불일치 예외 처리
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        BaseCode errorCode = CommonErrorCode.INVALID_VALUE;
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode));
     }

--- a/src/main/java/org/umc/travlocksserver/global/apiPayload/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/umc/travlocksserver/global/apiPayload/handler/GlobalExceptionHandler.java
@@ -1,0 +1,97 @@
+package org.umc.travlocksserver.global.apiPayload.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.umc.travlocksserver.global.apiPayload.ApiResponse;
+import org.umc.travlocksserver.global.apiPayload.code.BaseCode;
+import org.umc.travlocksserver.global.apiPayload.code.common.CommonErrorCode;
+import org.umc.travlocksserver.global.apiPayload.exception.GeneralException;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+// ✨ 애플리케이션 전체에서 발생하는 예외를 catch 해서 통일된 응답(JSON)으로 반환하는 역할을 하는 클래스
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // ⚪ GeneralException 처리
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneralException(GeneralException e) {
+        BaseCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+
+    // ⚪ 요청 헤더 누락 예외 처리
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingHeader(MissingRequestHeaderException e) {
+        BaseCode errorCode = CommonErrorCode.REQUEST_HEADER_EMPTY;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+
+    // ⚪ 지원하지 않는 HTTP 메서드 예외 처리
+    @ExceptionHandler({HttpRequestMethodNotSupportedException.class, MethodArgumentTypeMismatchException.class})
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(Exception e) {
+        BaseCode errorCode = CommonErrorCode.METHOD_NOT_ALLOWED;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+
+    // ⚪ 잘못된 URL 접근 예외 처리
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNoHandlerFound(NoHandlerFoundException e) {
+        BaseCode errorCode = CommonErrorCode.NOT_FOUND_URL;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+
+    // ⚪ DTO Validation 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationException(MethodArgumentNotValidException e) {
+        BaseCode commonErrorCode = CommonErrorCode.NOT_VALID_EXCEPTION;
+        /*
+        e.getBindingResult().getFieldErrors(): DTO 검증 중 실패한 필드들의 정보를 모두 가져옴
+        FieldError 객체
+        - field: 실패한 필드 이름
+        - defaultMessage: 어노테이션에서 설정한 오류메시지
+        */
+        Map<String, String> errors = e.getBindingResult().getFieldErrors().stream()
+                .collect(Collectors.toMap(
+                        FieldError::getField,
+                        error -> Optional.ofNullable(error.getDefaultMessage()).orElse("유효하지 않은 값입니다."), // default message가 null일 경우 기본 문자열로 대체
+                        (existing, replacement) -> existing  // 같은 필드 이름이 나오면, 기존값은 두고 새값은 무시한다.
+                ));
+        return ResponseEntity.status(commonErrorCode.getStatus())
+                .body(ApiResponse.fail(commonErrorCode, errors));
+    }
+
+    // ⚪ Media Type 오류 예외 처리
+    @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMediaTypeNotAcceptable(HttpMediaTypeNotAcceptableException e) {
+        BaseCode commonErrorCode = CommonErrorCode.HTTP_MEDIA_TYPE_NOT_ACCEPTABLE;
+        return ResponseEntity.status(commonErrorCode.getStatus())
+                .body(ApiResponse.fail(commonErrorCode));
+    }
+
+    // ⚪ 그 외의 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnhandledException(Exception e) {
+        log.error("예상치 못한 예외가 발생했습니다.", e);
+        BaseCode commonErrorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(commonErrorCode.getStatus())
+                .body(ApiResponse.fail(commonErrorCode));
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #3

## 📌 작업 내용
> 공통 예외 처리 응답을 설정해주었습니다.
- BaseCode 인터페이스를 생성하였습니다. 이를 상속받아 도메인별 에러/성공코드 생성해주시면 됩니다. common 디렉토리에 CommonErrorCode는 생성했으나, CommonSuccessCode는 불필요할 것 같다고 판단해 우선은 생성하지 않았습니다. 도메인 내에서 성공코드도 BaseCode 상속받아 사용하면 됩니다!
- GeneralException 생성 후, 예시로 MemberException 생성해두었습니다.
- GlobalExceptionHandler을 작성해 전역 예외처리 로직을 구현했습니다.
- ApiResponse를 작성해 공통응답 구조를 만들었습니다.
- Security 관련 의존성은 우선 주석 처리 해두었습니다.


## 🧪 테스트 결과
>  테스트 컨트롤러 생성 후 예외를 올바르게 ApiResponse 형태로 응답하는지 테스트 완료했습니다. (현재는 해당 컨트롤러 삭제)
<img width="944" height="702" alt="image" src="https://github.com/user-attachments/assets/4f65e91b-b928-4469-b1cb-4eba3d95f04e" />

## 📎 참고 사항 (선택)
> MemberException에 우선 CommonErrorCode를 넣어놔서 MemberErrorCode 생성 후 변경부탁드립니다!
<img width="537" height="147" alt="image" src="https://github.com/user-attachments/assets/3f85e0af-96b5-4163-8294-6f36ba71c868" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized API response format with success/failure, codes, messages, and optional data
  * Centralized error handling returning consistent error codes and HTTP statuses (including missing headers, invalid requests, not-found, unsupported methods, media type issues, and server errors)
  * Validation failures return field-specific error details

* **Chores**
  * Spring Security starter dependency disabled in build configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->