### PR TITLE
[feat] #28 유저 프로필 조회 API 구현

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberController.java
@@ -1,20 +1,29 @@
 package org.umc.travlocksserver.domain.member.controller;
 
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.umc.travlocksserver.domain.member.dto.request.MemberSignupRequestDTO;
+import org.umc.travlocksserver.domain.member.dto.response.MemberEmailExistsResponseDTO;
+import org.umc.travlocksserver.domain.member.dto.response.MemberNicknameExistsResponseDTO;
+import org.umc.travlocksserver.domain.member.dto.response.MemberProfileResponseDTO;
+import org.umc.travlocksserver.domain.member.dto.response.MemberSignupResponseDTO;
+import org.umc.travlocksserver.domain.member.exception.code.MemberSuccessCode;
+import org.umc.travlocksserver.domain.member.service.command.MemberSignupService;
+import org.umc.travlocksserver.domain.member.service.query.MemberEmailCheckService;
+import org.umc.travlocksserver.domain.member.service.query.MemberNicknameCheckService;
+import org.umc.travlocksserver.domain.member.service.query.MemberProfileQueryService;
+import org.umc.travlocksserver.global.response.SuccessResponse;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-import org.umc.travlocksserver.domain.member.dto.request.MemberSignupRequestDTO;
-import org.umc.travlocksserver.domain.member.dto.response.MemberEmailExistsResponseDTO;
-import org.umc.travlocksserver.domain.member.dto.response.MemberNicknameExistsResponseDTO;
-import org.umc.travlocksserver.domain.member.dto.response.MemberSignupResponseDTO;
-import org.umc.travlocksserver.domain.member.exception.code.MemberSuccessCode;
-import org.umc.travlocksserver.domain.member.service.query.MemberEmailCheckService;
-import org.umc.travlocksserver.domain.member.service.query.MemberNicknameCheckService;
-import org.umc.travlocksserver.domain.member.service.command.MemberSignupService;
-import org.umc.travlocksserver.global.response.SuccessResponse;
 
 @Validated
 @RestController
@@ -22,37 +31,49 @@ import org.umc.travlocksserver.global.response.SuccessResponse;
 @RequestMapping("/api/v1/members")
 public class MemberController implements MemberControllerDocs {
 
-    private final MemberEmailCheckService memberEmailCheckService;
-    private final MemberNicknameCheckService memberNicknameCheckService;
-    private final MemberSignupService memberSignupService;
+	private final MemberEmailCheckService memberEmailCheckService;
+	private final MemberNicknameCheckService memberNicknameCheckService;
+	private final MemberSignupService memberSignupService;
+	private final MemberProfileQueryService memberProfileQueryService;
 
-    @GetMapping("/email/exists")
-    public SuccessResponse<MemberEmailExistsResponseDTO> checkEmailExists(
-            @RequestParam
-            @NotBlank(message = "이메일은 필수입니다.") @Email(message = "올바르지 않은 이메일 형식입니다.")
-            String email) {
-        MemberEmailExistsResponseDTO data = memberEmailCheckService.checkEmailExists(email);
+	@GetMapping("/email/exists")
+	public SuccessResponse<MemberEmailExistsResponseDTO> checkEmailExists(
+		@RequestParam
+		@NotBlank(message = "이메일은 필수입니다.") @Email(message = "올바르지 않은 이메일 형식입니다.")
+		String email) {
+		MemberEmailExistsResponseDTO data = memberEmailCheckService.checkEmailExists(email);
 
-        return SuccessResponse.ok(MemberSuccessCode.EMAIL_EXISTS_CHECK_SUCCESS, data);
-    }
+		return SuccessResponse.ok(MemberSuccessCode.EMAIL_EXISTS_CHECK_SUCCESS, data);
+	}
 
-    @GetMapping("/nickname/exists")
-    public SuccessResponse<MemberNicknameExistsResponseDTO> checkNicknameExists(
-            @RequestParam
-            @NotBlank(message = "닉네임은 필수입니다.")
-            String nickname) {
-        MemberNicknameExistsResponseDTO data = memberNicknameCheckService.checkNicknameExists(nickname);
+	@GetMapping("/nickname/exists")
+	public SuccessResponse<MemberNicknameExistsResponseDTO> checkNicknameExists(
+		@RequestParam
+		@NotBlank(message = "닉네임은 필수입니다.")
+		String nickname) {
+		MemberNicknameExistsResponseDTO data = memberNicknameCheckService.checkNicknameExists(nickname);
 
-        return SuccessResponse.ok(MemberSuccessCode.NICKNAME_EXISTS_CHECK_SUCCESS, data);
-    }
+		return SuccessResponse.ok(MemberSuccessCode.NICKNAME_EXISTS_CHECK_SUCCESS, data);
+	}
 
-    @PostMapping("/signup")
-    public SuccessResponse<MemberSignupResponseDTO> signup(
-            @Valid
-            @RequestBody MemberSignupRequestDTO request
-    ) {
-        MemberSignupResponseDTO data = memberSignupService.signup(request);
+	@PostMapping("/signup")
+	public SuccessResponse<MemberSignupResponseDTO> signup(
+		@Valid
+		@RequestBody MemberSignupRequestDTO request
+	) {
+		MemberSignupResponseDTO data = memberSignupService.signup(request);
 
-        return SuccessResponse.ok(MemberSuccessCode.MEMBER_SIGNUP_SUCCESS, data);
-    }
+		return SuccessResponse.ok(MemberSuccessCode.MEMBER_SIGNUP_SUCCESS, data);
+	}
+
+	@GetMapping("/{memberId}/profile")
+	public SuccessResponse<MemberProfileResponseDTO> getMemberProfile(
+		@PathVariable Long memberId,
+		@RequestParam(name = "cursor", required = false) Long cursor,
+		@RequestParam(name = "limit", defaultValue = "9") int limit
+	) {
+		MemberProfileResponseDTO data = memberProfileQueryService.getMemberProfile(memberId, cursor, limit);
+
+		return SuccessResponse.ok(MemberSuccessCode.MEMBER_PROFILE_GET_SUCCESS, data);
+	}
 }

--- a/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package org.umc.travlocksserver.domain.member.controller;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -67,13 +68,17 @@ public class MemberController implements MemberControllerDocs {
 	}
 
 	@GetMapping("/{memberId}/profile")
-	public SuccessResponse<MemberProfileResponseDTO> getMemberProfile(
+	public ResponseEntity<SuccessResponse<MemberProfileResponseDTO>> getMemberProfile(
 		@PathVariable Long memberId,
 		@RequestParam(name = "cursor", required = false) Long cursor,
 		@RequestParam(name = "limit", defaultValue = "9") int limit
 	) {
+		MemberSuccessCode successCode = MemberSuccessCode.MEMBER_PROFILE_GET_SUCCESS;
+
 		MemberProfileResponseDTO data = memberProfileQueryService.getMemberProfile(memberId, cursor, limit);
 
-		return SuccessResponse.ok(MemberSuccessCode.MEMBER_PROFILE_GET_SUCCESS, data);
+		return ResponseEntity
+			.status(successCode.getStatus())
+			.body(SuccessResponse.ok(successCode, data));
 	}
 }

--- a/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
@@ -1,5 +1,6 @@
 package org.umc.travlocksserver.domain.member.controller;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.umc.travlocksserver.domain.member.dto.request.MemberSignupRequestDTO;
@@ -93,7 +94,7 @@ public interface MemberControllerDocs {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 (cursor/limit 범위 오류 등)", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
-	SuccessResponse<MemberProfileResponseDTO> getMemberProfile(
+	ResponseEntity<SuccessResponse<MemberProfileResponseDTO>> getMemberProfile(
 		@PathVariable Long memberId,
 		@RequestParam(name = "cursor", defaultValue = "0") Long cursor,
 		@RequestParam(name = "limit", defaultValue = "9") int limit

--- a/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
@@ -1,70 +1,101 @@
 package org.umc.travlocksserver.domain.member.controller;
 
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.umc.travlocksserver.domain.member.dto.request.MemberSignupRequestDTO;
+import org.umc.travlocksserver.domain.member.dto.response.MemberEmailExistsResponseDTO;
+import org.umc.travlocksserver.domain.member.dto.response.MemberNicknameExistsResponseDTO;
+import org.umc.travlocksserver.domain.member.dto.response.MemberProfileResponseDTO;
+import org.umc.travlocksserver.domain.member.dto.response.MemberSignupResponseDTO;
+import org.umc.travlocksserver.global.response.ErrorResponse;
+import org.umc.travlocksserver.global.response.SuccessResponse;
+
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import org.umc.travlocksserver.domain.member.dto.request.MemberSignupRequestDTO;
-import org.umc.travlocksserver.domain.member.dto.response.MemberEmailExistsResponseDTO;
-import org.umc.travlocksserver.domain.member.dto.response.MemberNicknameExistsResponseDTO;
-import org.umc.travlocksserver.domain.member.dto.response.MemberSignupResponseDTO;
-import org.umc.travlocksserver.global.response.SuccessResponse;
 
 public interface MemberControllerDocs {
 
-    @Operation(
-            summary = "이메일 중복 검사 API",
-            description = """
-            회원가입 시 이메일 중복 여부를 확인합니다.
-            
-            - data.exists=true  : 이미 사용 중인 이메일
-            - data.exists=false : 사용 가능한 이메일
-            """
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이메일 중복 검사 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패(이메일 형식/빈 값 등)")
-    })
-    SuccessResponse<MemberEmailExistsResponseDTO> checkEmailExists(
-            @NotBlank(message = "이메일은 필수입니다.") @Email(message = "올바르지 않은 이메일 형식입니다.")
-            String email
-    );
+	@Operation(
+		summary = "이메일 중복 검사 API",
+		description = """
+			회원가입 시 이메일 중복 여부를 확인합니다.
+			            
+			- data.exists=true  : 이미 사용 중인 이메일
+			- data.exists=false : 사용 가능한 이메일
+			"""
+	)
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이메일 중복 검사 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패(이메일 형식/빈 값 등)")
+	})
+	SuccessResponse<MemberEmailExistsResponseDTO> checkEmailExists(
+		@NotBlank(message = "이메일은 필수입니다.") @Email(message = "올바르지 않은 이메일 형식입니다.")
+		String email
+	);
 
-    @Operation(
-            summary = "닉네임 중복 검사 API",
-            description = """
-            회원가입 시 닉네임 중복 여부를 확인합니다.
-            
-            - data.exists=true  : 이미 사용 중인 닉네임
-            - data.exists=false : 사용 가능한 닉네임
-            """
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 중복 검사 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패(빈 값 등)")
-    })
-    SuccessResponse<MemberNicknameExistsResponseDTO> checkNicknameExists(
-            @NotBlank(message = "닉네임은 필수입니다.")
-            String nickname
-    );
+	@Operation(
+		summary = "닉네임 중복 검사 API",
+		description = """
+			회원가입 시 닉네임 중복 여부를 확인합니다.
+			            
+			- data.exists=true  : 이미 사용 중인 닉네임
+			- data.exists=false : 사용 가능한 닉네임
+			"""
+	)
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 중복 검사 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패(빈 값 등)")
+	})
+	SuccessResponse<MemberNicknameExistsResponseDTO> checkNicknameExists(
+		@NotBlank(message = "닉네임은 필수입니다.")
+		String nickname
+	);
 
-    @Operation(
-            summary = "회원가입 API",
-            description = """
-            회원가입을 진행합니다.
-            
-            - 이메일 인증 성공 후 발급된 signupToken이 필요합니다.
-            - signupToken에 매핑된 email과 요청 email이 일치해야 합니다.
-            """
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / 약관 오류 / 존재하지 않는 여행 스타일·테마 ID 포함"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패(예: signupToken 만료/불일치)"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "충돌(예: 이메일/닉네임 중복)")
-    })
-    SuccessResponse<MemberSignupResponseDTO> signup(
-            @Valid MemberSignupRequestDTO request
-    );
+	@Operation(
+		summary = "회원가입 API",
+		description = """
+			회원가입을 진행합니다.
+			            
+			- 이메일 인증 성공 후 발급된 signupToken이 필요합니다.
+			- signupToken에 매핑된 email과 요청 email이 일치해야 합니다.
+			"""
+	)
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / 약관 오류 / 존재하지 않는 여행 스타일·테마 ID 포함"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패(예: signupToken 만료/불일치)"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "충돌(예: 이메일/닉네임 중복)")
+	})
+	SuccessResponse<MemberSignupResponseDTO> signup(
+		@Valid MemberSignupRequestDTO request
+	);
+
+	@Operation(
+		summary = "유저 프로필 조회 API",
+		description = """
+			특정 유저의 프로필과 공개 템플릿 목록을 조회합니다.
+			    
+			[Query Params]
+			- cursor: 다음 목록 조회를 위한 커서(마지막으로 받은 templateId). 첫 조회는 null
+			- limit: 한 번에 가져올 템플릿 개수(기본 9)
+			    
+			[Cursor Pagination]
+			- hasNext=true 인 경우, 응답의 nextCursor 값을 다음 요청의 cursor로 전달하세요.
+			"""
+	)
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 프로필 조회 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 (cursor/limit 범위 오류 등)", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	SuccessResponse<MemberProfileResponseDTO> getMemberProfile(
+		@PathVariable Long memberId,
+		@RequestParam(name = "cursor", defaultValue = "0") Long cursor,
+		@RequestParam(name = "limit", defaultValue = "9") int limit
+	);
 }

--- a/src/main/java/org/umc/travlocksserver/domain/member/dto/response/MemberProfileResponseDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/dto/response/MemberProfileResponseDTO.java
@@ -1,0 +1,12 @@
+package org.umc.travlocksserver.domain.member.dto.response;
+
+import org.umc.travlocksserver.domain.template.dto.response.TemplateCursorResponseDTO;
+
+public record MemberProfileResponseDTO(
+	Long memberId,
+	String nickname,
+	String introduction,
+	String profileImageUrl,
+	TemplateCursorResponseDTO templates
+) {
+}

--- a/src/main/java/org/umc/travlocksserver/domain/member/entity/Member.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/entity/Member.java
@@ -5,8 +5,6 @@ import lombok.*;
 import org.umc.travlocksserver.domain.member.enums.MemberStatus;
 import org.umc.travlocksserver.global.entity.SoftDeleteBaseEntity;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -34,6 +32,9 @@ public class Member extends SoftDeleteBaseEntity {
 
     @Column(name = "email", length = 255, nullable = false)
     private String email;
+
+	@Column(name = "profile_image_url", nullable = false, length = 255)
+	private String profileImageUrl;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 10, nullable = false)

--- a/src/main/java/org/umc/travlocksserver/domain/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/exception/code/MemberErrorCode.java
@@ -1,27 +1,30 @@
 package org.umc.travlocksserver.domain.member.exception.code;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.umc.travlocksserver.global.code.BaseCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum MemberErrorCode implements BaseCode {
 
-    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
-    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
+	EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+	NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
 
-    SIGNUP_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 signupToken입니다."),
-    SIGNUP_TOKEN_EMAIL_MISMATCH(HttpStatus.UNAUTHORIZED, "signupToken의 이메일 정보가 일치하지 않습니다."),
+	SIGNUP_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 signupToken입니다."),
+	SIGNUP_TOKEN_EMAIL_MISMATCH(HttpStatus.UNAUTHORIZED, "signupToken의 이메일 정보가 일치하지 않습니다."),
 
-    POLICY_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 약관이 포함되어 있습니다."),
-    REQUIRED_POLICY_NOT_AGREED(HttpStatus.BAD_REQUEST, "필수 약관에 동의해야 합니다."),
+	POLICY_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 약관이 포함되어 있습니다."),
+	REQUIRED_POLICY_NOT_AGREED(HttpStatus.BAD_REQUEST, "필수 약관에 동의해야 합니다."),
 
-    TRAVEL_STYLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 여행 스타일 ID가 포함되어 있습니다."),
-    TRAVEL_THEME_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 여행 테마 ID가 포함되어 있습니다.");
+	TRAVEL_STYLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 여행 스타일 ID가 포함되어 있습니다."),
+	TRAVEL_THEME_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 여행 테마 ID가 포함되어 있습니다."),
 
-    private final HttpStatus status;
-    private final String message;
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
+
+	private final HttpStatus status;
+	private final String message;
 }
 

--- a/src/main/java/org/umc/travlocksserver/domain/member/exception/code/MemberSuccessCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/exception/code/MemberSuccessCode.java
@@ -1,28 +1,32 @@
 package org.umc.travlocksserver.domain.member.exception.code;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import org.umc.travlocksserver.global.code.BaseCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum MemberSuccessCode implements BaseCode {
 
-    EMAIL_EXISTS_CHECK_SUCCESS(
-            HttpStatus.OK,
-            "이메일 중복 검사에 성공했습니다."
-    ),
-    NICKNAME_EXISTS_CHECK_SUCCESS(
-            HttpStatus.OK,
-            "닉네임 중복 검사에 성공했습니다."
-    ),
-    MEMBER_SIGNUP_SUCCESS(
-            HttpStatus.CREATED,
-            "회원가입이 완료되었습니다."
-    ),
-    ;
+	EMAIL_EXISTS_CHECK_SUCCESS(
+		HttpStatus.OK,
+		"이메일 중복 검사에 성공했습니다."
+	),
+	NICKNAME_EXISTS_CHECK_SUCCESS(
+		HttpStatus.OK,
+		"닉네임 중복 검사에 성공했습니다."
+	),
+	MEMBER_SIGNUP_SUCCESS(
+		HttpStatus.CREATED,
+		"회원가입이 완료되었습니다."
+	),
+	MEMBER_PROFILE_GET_SUCCESS(
+		HttpStatus.OK,
+		"유저 프로필 조회에 성공했습니다."
+	);
 
-    private final HttpStatus status;
-    private final String message;
+	private final HttpStatus status;
+	private final String message;
 }

--- a/src/main/java/org/umc/travlocksserver/domain/member/service/query/MemberProfileQueryService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/service/query/MemberProfileQueryService.java
@@ -7,12 +7,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.umc.travlocksserver.domain.member.dto.response.MemberProfileResponseDTO;
 import org.umc.travlocksserver.domain.member.entity.Member;
 import org.umc.travlocksserver.domain.member.exception.MemberException;
+import org.umc.travlocksserver.domain.member.exception.code.MemberErrorCode;
 import org.umc.travlocksserver.domain.member.repository.MemberRepository;
 import org.umc.travlocksserver.domain.template.dto.response.TemplateCursorResponseDTO;
 import org.umc.travlocksserver.domain.template.dto.response.TemplateSummaryDTO;
 import org.umc.travlocksserver.domain.template.entity.Template;
 import org.umc.travlocksserver.domain.template.repository.TemplateRepository;
-import org.umc.travlocksserver.global.code.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,7 +26,7 @@ public class MemberProfileQueryService {
 
 	public MemberProfileResponseDTO getMemberProfile(Long memberId, Long cursor, int limit) {
 		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
 		int safeLimit = Math.min(Math.max(limit, 1), 50);
 

--- a/src/main/java/org/umc/travlocksserver/domain/member/service/query/MemberProfileQueryService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/service/query/MemberProfileQueryService.java
@@ -1,0 +1,65 @@
+package org.umc.travlocksserver.domain.member.service.query;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.umc.travlocksserver.domain.member.dto.response.MemberProfileResponseDTO;
+import org.umc.travlocksserver.domain.member.entity.Member;
+import org.umc.travlocksserver.domain.member.exception.MemberException;
+import org.umc.travlocksserver.domain.member.repository.MemberRepository;
+import org.umc.travlocksserver.domain.template.dto.response.TemplateCursorResponseDTO;
+import org.umc.travlocksserver.domain.template.dto.response.TemplateSummaryDTO;
+import org.umc.travlocksserver.domain.template.entity.Template;
+import org.umc.travlocksserver.domain.template.repository.TemplateRepository;
+import org.umc.travlocksserver.global.code.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberProfileQueryService {
+
+	private final MemberRepository memberRepository;
+	private final TemplateRepository templateRepository;
+
+	public MemberProfileResponseDTO getMemberProfile(Long memberId, Long cursor, int limit) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+		int safeLimit = Math.min(Math.max(limit, 1), 50);
+
+		List<Template> templates = (cursor == null)
+			? templateRepository.findPublicTemplatesFirst(memberId, safeLimit + 1)
+			: templateRepository.findPublicTemplatesAfterCursor(memberId, cursor, safeLimit + 1);
+
+		boolean hasNext = templates.size() > safeLimit;
+		if (hasNext)
+			templates = templates.subList(0, safeLimit);
+
+		Long nextCursor = hasNext ? templates.get(templates.size() - 1).getId() : null;
+
+		List<TemplateSummaryDTO> items = templates.stream()
+			.map(t -> new TemplateSummaryDTO(
+				t.getId(),
+				t.getTitle(),
+				t.getCoverImageUrl(),
+				t.getFavoriteCount(),
+				t.getAvgRating(),
+				t.getCreatedAt()
+			))
+			.toList();
+
+		TemplateCursorResponseDTO templateCursorResponseDTO =
+			new TemplateCursorResponseDTO(nextCursor, hasNext, items);
+
+		return new MemberProfileResponseDTO(
+			member.getId(),
+			member.getNickname(),
+			member.getIntroduction(),
+			member.getProfileImageUrl(),
+			templateCursorResponseDTO
+		);
+	}
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/dto/response/TemplateCursorResponseDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/dto/response/TemplateCursorResponseDTO.java
@@ -1,0 +1,10 @@
+package org.umc.travlocksserver.domain.template.dto.response;
+
+import java.util.List;
+
+public record TemplateCursorResponseDTO(
+	Long nextCursor,
+	boolean hasNext,
+	List<TemplateSummaryDTO> items
+) {
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/dto/response/TemplateSummaryDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/dto/response/TemplateSummaryDTO.java
@@ -1,0 +1,13 @@
+package org.umc.travlocksserver.domain.template.dto.response;
+
+import java.time.LocalDateTime;
+
+public record TemplateSummaryDTO(
+	Long templateId,
+	String title,
+	String coverImageUrl,
+	Integer favoriteCount,
+	Double avgRating,
+	LocalDateTime createdAt
+) {
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateRepository.java
@@ -1,0 +1,39 @@
+package org.umc.travlocksserver.domain.template.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.umc.travlocksserver.domain.template.entity.Template;
+
+public interface TemplateRepository extends JpaRepository<Template, Long> {
+
+	@Query("""
+		    select t from Template t
+		    where t.owner.id = :memberId
+		      and t.isPublic = true
+		    order by t.id desc
+		""")
+	List<Template> findPublicTemplatesFirst(@Param("memberId") Long memberId, Pageable pageable);
+
+	@Query("""
+		    select t from Template t
+		    where t.owner.id = :memberId
+		      and t.isPublic = true
+		      and t.id < :cursor
+		    order by t.id desc
+		""")
+	List<Template> findPublicTemplatesAfterCursor(@Param("memberId") Long memberId, @Param("cursor") Long cursor,
+		Pageable pageable);
+
+	default List<Template> findPublicTemplatesFirst(Long memberId, int limit) {
+		return findPublicTemplatesFirst(memberId, PageRequest.of(0, limit));
+	}
+
+	default List<Template> findPublicTemplatesAfterCursor(Long memberId, Long cursor, int limit) {
+		return findPublicTemplatesAfterCursor(memberId, cursor, PageRequest.of(0, limit));
+	}
+}

--- a/src/main/java/org/umc/travlocksserver/global/code/ErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/global/code/ErrorCode.java
@@ -1,8 +1,9 @@
 package org.umc.travlocksserver.global.code;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
@@ -16,6 +17,7 @@ public enum ErrorCode implements BaseCode {
 
 	// 404
 	NOT_FOUND_URL(HttpStatus.NOT_FOUND, "존재하지 않는 URL 입니다."),
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 
 	// 405
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),

--- a/src/main/java/org/umc/travlocksserver/global/code/ErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/global/code/ErrorCode.java
@@ -17,7 +17,6 @@ public enum ErrorCode implements BaseCode {
 
 	// 404
 	NOT_FOUND_URL(HttpStatus.NOT_FOUND, "존재하지 않는 URL 입니다."),
-	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 
 	// 405
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #28

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 유저 프로필 조회 API 구현
  - 템플릿 작성자의 닉네임/한줄소개/캐릭터 이미지/공개한 템플릿 리스트 조회
  - 커서 기반 페이징 적용
  - Member 엔티티 profileImageUrl 컬럼 추가


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
<img width="1579" height="789" alt="image" src="https://github.com/user-attachments/assets/42120d40-43d7-4f90-ae5e-f769eba97278" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

코드 컨벤션 적용으로 일부 파일이 전반적으로 수정되었습니다.
