### PR TITLE
[feat] #32 인기있는 템플릿 조회 api 구현

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/template/code/SuccessCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/code/SuccessCode.java
@@ -1,0 +1,17 @@
+package org.umc.travlocksserver.domain.template.code;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.umc.travlocksserver.global.code.BaseCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessCode implements BaseCode {
+
+    HOME_GET_POPULAR_TEMPLATES_SUCCESS(HttpStatus.OK, "홈 화면 인기 템플릿 조회에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/code/TemplateSuccessCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/code/TemplateSuccessCode.java
@@ -8,7 +8,7 @@ import org.umc.travlocksserver.global.code.BaseCode;
 
 @Getter
 @RequiredArgsConstructor
-public enum SuccessCode implements BaseCode {
+public enum TemplateSuccessCode implements BaseCode {
 
     HOME_GET_POPULAR_TEMPLATES_SUCCESS(HttpStatus.OK, "홈 화면 인기 템플릿 조회에 성공했습니다.");
 

--- a/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
@@ -4,9 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.umc.travlocksserver.domain.template.code.SuccessCode;
+import org.umc.travlocksserver.domain.template.code.TemplateSuccessCode;
 import org.umc.travlocksserver.domain.template.dto.response.PopularTemplateResponse;
 import org.umc.travlocksserver.domain.template.service.TemplateQueryService;
 import org.umc.travlocksserver.global.response.SuccessResponse;
@@ -22,7 +21,7 @@ public class TemplateController implements TemplateControllerDocs {
 
     @GetMapping("/popular")
     public ResponseEntity<SuccessResponse<List<PopularTemplateResponse>>> getPopularTemplates() {
-        SuccessCode successCode = SuccessCode.HOME_GET_POPULAR_TEMPLATES_SUCCESS;
+        TemplateSuccessCode successCode = TemplateSuccessCode.HOME_GET_POPULAR_TEMPLATES_SUCCESS;
         return ResponseEntity
                 .status(successCode.getStatus())
                 .body(

--- a/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
@@ -1,0 +1,35 @@
+package org.umc.travlocksserver.domain.template.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.umc.travlocksserver.domain.template.code.SuccessCode;
+import org.umc.travlocksserver.domain.template.dto.response.PopularTemplateResponse;
+import org.umc.travlocksserver.domain.template.service.TemplateQueryService;
+import org.umc.travlocksserver.global.response.SuccessResponse;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/templates")
+public class TemplateController implements TemplateControllerDocs {
+
+    private final TemplateQueryService templateQueryService;
+
+    @GetMapping("/popular")
+    public ResponseEntity<SuccessResponse<List<PopularTemplateResponse>>> getPopularTemplates() {
+        SuccessCode successCode = SuccessCode.HOME_GET_POPULAR_TEMPLATES_SUCCESS;
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(
+                        SuccessResponse.ok(
+                                successCode,
+                                templateQueryService.getPopularTemplates(10)
+                        )
+                );
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateControllerDocs.java
@@ -1,0 +1,38 @@
+package org.umc.travlocksserver.domain.template.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.umc.travlocksserver.domain.template.dto.response.PopularTemplateResponse;
+import org.umc.travlocksserver.global.response.SuccessResponse;
+
+import java.util.List;
+
+@Tag(name = "Template")
+public interface TemplateControllerDocs {
+
+    @Operation(
+            summary = "홈 화면 인기 템플릿 조회",
+            description = """
+                홈 화면 하단에 노출되는 인기 템플릿 목록을 조회합니다.
+                
+                - 공개된 템플릿(isPublic = true)만 조회됩니다.
+                - 리믹스 수(remixCount) 기준 내림차순으로 정렬됩니다.
+                - 최대 10개의 템플릿을 반환합니다.
+                """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "홈 화면 인기 템플릿 조회 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(
+                            implementation = SuccessResponse.class
+                    )
+            )
+    )
+    ResponseEntity<SuccessResponse<List<PopularTemplateResponse>>> getPopularTemplates();
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/dto/response/PopularTemplateResponse.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/dto/response/PopularTemplateResponse.java
@@ -1,0 +1,15 @@
+package org.umc.travlocksserver.domain.template.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record PopularTemplateResponse(
+        Long templateId,
+        String coverImageUrl,
+        String title,
+        Double avgRating,
+        Integer remixCount,
+        String travelTheme,
+        String ownerNickname
+) {
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateRepository.java
@@ -1,0 +1,25 @@
+package org.umc.travlocksserver.domain.template.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.umc.travlocksserver.domain.template.entity.Template;
+
+import java.util.List;
+
+public interface TemplateRepository extends JpaRepository<Template, Long> {
+
+    @Query("""
+        SELECT t
+        FROM Template t
+        JOIN FETCH t.travelTheme
+        JOIN FETCH t.owner
+        WHERE t.isPublic = true
+          AND t.deletedAt IS NULL
+        ORDER BY
+            t.remixCount DESC,
+            t.favoriteCount DESC,
+            t.avgRating DESC
+    """)
+    List<Template> findPopularTemplates(Pageable pageable);
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/service/TemplateQueryService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/service/TemplateQueryService.java
@@ -1,0 +1,37 @@
+package org.umc.travlocksserver.domain.template.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.umc.travlocksserver.domain.template.dto.response.PopularTemplateResponse;
+import org.umc.travlocksserver.domain.template.entity.Template;
+import org.umc.travlocksserver.domain.template.repository.TemplateRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TemplateQueryService {
+
+    private final TemplateRepository templateRepository;
+
+    public List<PopularTemplateResponse> getPopularTemplates(int limit) {
+
+        return templateRepository.findPopularTemplates(PageRequest.of(0, limit))
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private PopularTemplateResponse toResponse(Template template) {
+        return PopularTemplateResponse.builder()
+                .templateId(template.getId())
+                .coverImageUrl(template.getCoverImageUrl())
+                .title(template.getTitle())
+                .avgRating(template.getAvgRating())
+                .remixCount(template.getRemixCount())
+                .travelTheme(template.getTravelTheme().getContent())
+                .ownerNickname(template.getOwner().getNickname())
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> #32


## 📌 작업 내용
> 홈 화면 하단에 노출되는 ‘인기 템플릿’ 조회 기능 구현



## 🧪 테스트 결과
<img width="1376" height="736" alt="image" src="https://github.com/user-attachments/assets/31a09aba-7121-4534-bcb2-f60187ef44de" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 정책집 기준에 따라 리믹스 수 → 즐겨찾기 수 → 평점 순으로 인기 지표를 적용하여 홈 화면 하단에 노출될 인기 템플릿 목록을 반환하도록 구성하였습니다!