### PR TITLE
[feat] #23 블록 생성 API 구현

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/location/constant/CityErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/location/constant/CityErrorCode.java
@@ -1,0 +1,18 @@
+package org.umc.travlocksserver.domain.location.constant;
+
+import org.springframework.http.HttpStatus;
+import org.umc.travlocksserver.global.code.BaseCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CityErrorCode implements BaseCode {
+
+	CITY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 도시를 찾을 수 없습니다."),
+	;
+
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/org/umc/travlocksserver/domain/location/dto/CityDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/location/dto/CityDTO.java
@@ -1,0 +1,17 @@
+package org.umc.travlocksserver.domain.location.dto;
+
+import org.umc.travlocksserver.domain.location.entity.City;
+
+public record CityDTO(
+	Long id,
+	String name,
+	RegionDTO region
+) {
+	public static CityDTO from(City city) {
+		return new CityDTO(
+			city.getId(),
+			city.getName(),
+			RegionDTO.from(city.getRegion())
+		);
+	}
+}

--- a/src/main/java/org/umc/travlocksserver/domain/location/dto/RegionDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/location/dto/RegionDTO.java
@@ -1,0 +1,15 @@
+package org.umc.travlocksserver.domain.location.dto;
+
+import org.umc.travlocksserver.domain.location.entity.Region;
+
+public record RegionDTO(
+	Long id,
+	String name
+) {
+	public static RegionDTO from(Region region) {
+		return new RegionDTO(
+			region.getId(),
+			region.getName()
+		);
+	}
+}

--- a/src/main/java/org/umc/travlocksserver/domain/location/exception/CityException.java
+++ b/src/main/java/org/umc/travlocksserver/domain/location/exception/CityException.java
@@ -1,0 +1,10 @@
+package org.umc.travlocksserver.domain.location.exception;
+
+import org.umc.travlocksserver.global.code.BaseCode;
+import org.umc.travlocksserver.global.exception.GeneralException;
+
+public class CityException extends GeneralException {
+	public CityException(BaseCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/org/umc/travlocksserver/domain/location/repository/CityRepository.java
+++ b/src/main/java/org/umc/travlocksserver/domain/location/repository/CityRepository.java
@@ -1,0 +1,15 @@
+package org.umc.travlocksserver.domain.location.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.umc.travlocksserver.domain.location.entity.City;
+
+@Repository
+public interface CityRepository extends JpaRepository<City,Long> {
+
+	@EntityGraph(attributePaths = {"region"})
+	Optional<City> findWithRegionById(Long id);
+}

--- a/src/main/java/org/umc/travlocksserver/domain/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/exception/code/MemberErrorCode.java
@@ -19,7 +19,9 @@ public enum MemberErrorCode implements BaseCode {
     REQUIRED_POLICY_NOT_AGREED(HttpStatus.BAD_REQUEST, "필수 약관에 동의해야 합니다."),
 
     TRAVEL_STYLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 여행 스타일 ID가 포함되어 있습니다."),
-    TRAVEL_THEME_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 여행 테마 ID가 포함되어 있습니다.");
+    TRAVEL_THEME_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 여행 테마 ID가 포함되어 있습니다."),
+
+	MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 회원입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/constant/VlockErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/constant/VlockErrorCode.java
@@ -1,0 +1,19 @@
+package org.umc.travlocksserver.domain.vlock.constant;
+
+import org.springframework.http.HttpStatus;
+import org.umc.travlocksserver.global.code.BaseCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum VlockErrorCode implements BaseCode {
+
+	CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다."),
+	VLOCK_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 블록입니다.")
+	;
+
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/constant/VlockSuccessCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/constant/VlockSuccessCode.java
@@ -1,0 +1,21 @@
+package org.umc.travlocksserver.domain.vlock.constant;
+
+import org.springframework.http.HttpStatus;
+import org.umc.travlocksserver.global.code.BaseCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum VlockSuccessCode implements BaseCode {
+
+	VLOCK_CREATE_SUCCESS(
+		HttpStatus.CREATED,
+		"블록 생성이 완료되었습니다."
+	)
+	;
+
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockController.java
@@ -1,0 +1,32 @@
+package org.umc.travlocksserver.domain.vlock.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.umc.travlocksserver.domain.vlock.dto.vlock.VlockRequestDTO;
+import org.umc.travlocksserver.domain.vlock.dto.vlock.VlockResponseDTO;
+import org.umc.travlocksserver.domain.vlock.service.VlockService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/vlocks")
+public class VlockController {
+
+	private final VlockService vlockService;
+
+	@PostMapping
+	public ResponseEntity<VlockResponseDTO> createVlock(
+		@AuthenticationPrincipal Long memberId,
+		@Valid @RequestBody VlockRequestDTO request) {
+		VlockResponseDTO response = vlockService.createVlock(memberId, request);
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/vlocks")
-public class VlockController {
+public class VlockController implements VlockControllerDocs {
 
 	private final VlockService vlockService;
 

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockController.java
@@ -7,9 +7,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.umc.travlocksserver.domain.vlock.constant.VlockSuccessCode;
 import org.umc.travlocksserver.domain.vlock.dto.vlock.VlockRequestDTO;
 import org.umc.travlocksserver.domain.vlock.dto.vlock.VlockResponseDTO;
 import org.umc.travlocksserver.domain.vlock.service.VlockService;
+import org.umc.travlocksserver.global.response.SuccessResponse;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,11 +24,13 @@ public class VlockController implements VlockControllerDocs {
 	private final VlockService vlockService;
 
 	@PostMapping
-	public ResponseEntity<VlockResponseDTO> createVlock(
+	public ResponseEntity<SuccessResponse<VlockResponseDTO>> createVlock(
 		@AuthenticationPrincipal Long memberId,
 		@Valid @RequestBody VlockRequestDTO request) {
 		VlockResponseDTO response = vlockService.createVlock(memberId, request);
 
-		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
+			.body(SuccessResponse.ok(VlockSuccessCode.VLOCK_CREATE_SUCCESS, response));
 	}
 }

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockControllerDocs.java
@@ -1,0 +1,29 @@
+package org.umc.travlocksserver.domain.vlock.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.umc.travlocksserver.domain.vlock.dto.vlock.VlockRequestDTO;
+import org.umc.travlocksserver.domain.vlock.dto.vlock.VlockResponseDTO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+
+public interface VlockControllerDocs {
+
+	@Operation(
+		summary = "블록 생성 API",
+		description = """
+		템플릿에 사용될 블록을 생성합니다.
+		"""
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "201", description = "블록 생성 성공"),
+		@ApiResponse(responseCode = "404", description = "categoryId or cityId가 누락된 경우 실패")
+	})
+	ResponseEntity<VlockResponseDTO> createVlock(
+		@AuthenticationPrincipal Long memberId,
+		@Valid @RequestBody VlockRequestDTO request);
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockControllerDocs.java
@@ -5,6 +5,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.umc.travlocksserver.domain.vlock.dto.vlock.VlockRequestDTO;
 import org.umc.travlocksserver.domain.vlock.dto.vlock.VlockResponseDTO;
+import org.umc.travlocksserver.global.response.SuccessResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,7 +24,7 @@ public interface VlockControllerDocs {
 		@ApiResponse(responseCode = "201", description = "블록 생성 성공"),
 		@ApiResponse(responseCode = "404", description = "categoryId or cityId가 누락된 경우 실패")
 	})
-	ResponseEntity<VlockResponseDTO> createVlock(
+	ResponseEntity<SuccessResponse<VlockResponseDTO>> createVlock(
 		@AuthenticationPrincipal Long memberId,
 		@Valid @RequestBody VlockRequestDTO request);
 }

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/dto/vlock/VlockRequestDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/dto/vlock/VlockRequestDTO.java
@@ -1,0 +1,20 @@
+package org.umc.travlocksserver.domain.vlock.dto.vlock;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record VlockRequestDTO(
+	@NotBlank(message = "이름은 필수입니다.")
+	String name,
+
+	@NotBlank(message = "주소는 필수입니다.")
+	String address,
+
+	Long categoryId,
+	Long cityId,
+
+	String memo,
+
+	Double latitude,
+	Double longitude
+) {
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/dto/vlock/VlockResponseDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/dto/vlock/VlockResponseDTO.java
@@ -1,0 +1,51 @@
+package org.umc.travlocksserver.domain.vlock.dto.vlock;
+
+import org.umc.travlocksserver.domain.location.dto.CityDTO;
+import org.umc.travlocksserver.domain.vlock.dto.vlockCategory.VlockCategoryDTO;
+import org.umc.travlocksserver.domain.vlock.entity.Vlock;
+
+public record VlockResponseDTO(
+	Long id,
+	Long memberId,
+
+	VlockCategoryDTO vlockCategory,
+
+	CityDTO city,
+
+	String name,
+	String address,
+	String memo,
+	String coverImgUrl,
+	String linkUrl,
+
+	Double latitude,
+	Double longitude,
+
+	Integer usageCount,
+
+	Boolean isPublic
+) {
+	public static VlockResponseDTO from(Vlock vlock) {
+		return new VlockResponseDTO(
+			vlock.getId(),
+			vlock.getOwner().getId(),
+
+			VlockCategoryDTO.from(vlock.getVlockCategory()),
+
+			CityDTO.from(vlock.getCity()),
+
+			vlock.getName(),
+			vlock.getAddress(),
+			vlock.getMemo(),
+			vlock.getCoverImgUrl(),
+			vlock.getLinkUrl(),
+
+			vlock.getLatitude(),
+			vlock.getLongitude(),
+
+			vlock.getUsageCount(),
+
+			vlock.getIsPublic()
+		);
+	}
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/dto/vlockCategory/VlockCategoryDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/dto/vlockCategory/VlockCategoryDTO.java
@@ -1,0 +1,19 @@
+package org.umc.travlocksserver.domain.vlock.dto.vlockCategory;
+
+import org.umc.travlocksserver.domain.vlock.entity.VlockCategory;
+
+public record VlockCategoryDTO(
+	Long id,
+
+	String name,
+
+	Integer stayMinutes
+) {
+	public static VlockCategoryDTO from(VlockCategory vlockCategory) {
+		return new VlockCategoryDTO(
+			vlockCategory.getId(),
+			vlockCategory.getName(),
+			vlockCategory.getStayMinutes()
+		);
+	}
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/entity/Vlock.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/entity/Vlock.java
@@ -9,9 +9,7 @@ import org.umc.travlocksserver.global.entity.SoftDeleteBaseEntity;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
 @Entity
-@Table(name = "vlocks")
 public class Vlock extends SoftDeleteBaseEntity {
 
     @Id
@@ -37,31 +35,73 @@ public class Vlock extends SoftDeleteBaseEntity {
     @Column(nullable = false, length = 20)
     private String name;
 
-    @Column(name = "cover_img_url", nullable = false, length = 255)
+    @Column(nullable = false)
     private String coverImgUrl;
 
     @Column(nullable = false)
     private Double latitude;
 
-    @Column(name = "longitude", nullable = false)
+    @Column(nullable = false)
     private Double longitude;
 
-    @Column(nullable = false, length = 255)
+    @Column(nullable = false)
     private String address;
 
     @Column(length = 200)
     private String memo;
 
-    @Column(name = "link_url", length = 255)
     private String linkUrl;
 
-    @Column(name = "avg_rating")
-    private Double avgRating;
+    @Column(nullable = false)
+    private Integer usageCount;
 
-    @Builder.Default
-    @Column(name = "usage_count", nullable = false)
-    private Integer usageCount = 0;
-
-    @Column(name = "is_public", nullable = false)
+    @Column(nullable = false)
     private Boolean isPublic;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private Vlock(
+		VlockCategory vlockCategory,
+		City city,
+		Member owner,
+		String name,
+		Double latitude,
+		Double longitude,
+		String address,
+		String memo
+	) {
+		this.vlockCategory = vlockCategory;
+		this.city = city;
+		this.owner = owner;
+		this.name = name;
+		this.latitude = latitude;
+		this.longitude = longitude;
+		this.address = address;
+		this.memo = memo;
+		this.coverImgUrl = "";
+		this.linkUrl = "";
+		this.usageCount = 0;
+		this.isPublic = false;
+	}
+
+	public static Vlock create(
+		VlockCategory category,
+		City city,
+		Member owner,
+		String name,
+		Double latitude,
+		Double longitude,
+		String address,
+		String memo
+	) {
+		return Vlock.builder()
+			.vlockCategory(category)
+			.city(city)
+			.owner(owner)
+			.name(name)
+			.latitude(latitude)
+			.longitude(longitude)
+			.address(address)
+			.memo(memo)
+			.build();
+	}
 }

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/entity/VlockCategory.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/entity/VlockCategory.java
@@ -14,12 +14,12 @@ public class VlockCategory extends CreatedSoftDeleteBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "vlock_category_id")
+	@Column(name = "vlock_category_id")
     private Long id;
 
     @Column(nullable = false, length = 10)
     private String name;
 
-    @Column(name = "stay_minutes", nullable = false)
+    @Column(nullable = false)
     private Integer stayMinutes;
 }

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/exception/VlockException.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/exception/VlockException.java
@@ -1,0 +1,10 @@
+package org.umc.travlocksserver.domain.vlock.exception;
+
+import org.umc.travlocksserver.global.code.BaseCode;
+import org.umc.travlocksserver.global.exception.GeneralException;
+
+public class VlockException extends GeneralException {
+	public VlockException(BaseCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/repository/VlockCategoryRepository.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/repository/VlockCategoryRepository.java
@@ -1,0 +1,9 @@
+package org.umc.travlocksserver.domain.vlock.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.umc.travlocksserver.domain.vlock.entity.VlockCategory;
+
+@Repository
+public interface VlockCategoryRepository extends JpaRepository<VlockCategory, Long> {
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/repository/VlockRepository.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/repository/VlockRepository.java
@@ -1,0 +1,9 @@
+package org.umc.travlocksserver.domain.vlock.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.umc.travlocksserver.domain.vlock.entity.Vlock;
+
+@Repository
+public interface VlockRepository extends JpaRepository<Vlock,Long> {
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/service/VlockService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/service/VlockService.java
@@ -1,0 +1,60 @@
+package org.umc.travlocksserver.domain.vlock.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.umc.travlocksserver.domain.location.constant.CityErrorCode;
+import org.umc.travlocksserver.domain.location.entity.City;
+import org.umc.travlocksserver.domain.location.exception.CityException;
+import org.umc.travlocksserver.domain.location.repository.CityRepository;
+import org.umc.travlocksserver.domain.member.entity.Member;
+import org.umc.travlocksserver.domain.member.exception.MemberException;
+import org.umc.travlocksserver.domain.member.exception.code.MemberErrorCode;
+import org.umc.travlocksserver.domain.member.repository.MemberRepository;
+import org.umc.travlocksserver.domain.vlock.dto.vlock.VlockRequestDTO;
+import org.umc.travlocksserver.domain.vlock.dto.vlock.VlockResponseDTO;
+import org.umc.travlocksserver.domain.vlock.entity.Vlock;
+import org.umc.travlocksserver.domain.vlock.entity.VlockCategory;
+import org.umc.travlocksserver.domain.vlock.exception.VlockException;
+import org.umc.travlocksserver.domain.vlock.constant.VlockErrorCode;
+import org.umc.travlocksserver.domain.vlock.repository.VlockCategoryRepository;
+import org.umc.travlocksserver.domain.vlock.repository.VlockRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class VlockService {
+
+	private final VlockRepository vlockRepository;
+	private final VlockCategoryRepository vlockCategoryRepository;
+	private final CityRepository cityRepository;
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public VlockResponseDTO createVlock(Long memberId, VlockRequestDTO requestDTO) {
+
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+		VlockCategory vlockCategory = vlockCategoryRepository.findById(requestDTO.categoryId())
+			.orElseThrow(() -> new VlockException(VlockErrorCode.CATEGORY_NOT_FOUND));
+
+		City city = cityRepository.findWithRegionById(requestDTO.cityId())
+			.orElseThrow(() -> new CityException(CityErrorCode.CITY_NOT_FOUND));
+
+		Vlock vlock = Vlock.create(
+			vlockCategory,
+			city,
+			member,
+			requestDTO.name(),
+			requestDTO.latitude(),
+			requestDTO.longitude(),
+			requestDTO.address(),
+			requestDTO.memo()
+		);
+
+		Vlock saved = vlockRepository.save(vlock);
+
+		return VlockResponseDTO.from(saved);
+	}
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #23 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

### Vlock 생성 API 구현
- API 엔드포인트 추가: POST /vlocks
- Vlock 생성 비즈니스 로직 구현 (`VlockService`)
  - 사용자(Member), 카테고리(VlockCategory), 도시(City) 유효성 검증
  - 위도(latitude), 경도(longitude), 주소(address), 메모(memo) 등 상세 정보 저장
  - Vlock 엔티티 생성 및 DB 저장
- DTO 정의
  - request: `VlockRequestDTO `(카테고리 ID, 도시 ID, 이름, 좌표 등)
  - response: 
    - `VlockResponseDTO `(생성된 Vlock 상세 정보 전환)
    - `VlockCategoryDTO `(Vlock에 해당되는 카테고리 상세 정보 중첩 DTO)
    - `CityDTO `(Vlock에 해당되는 도시 상세 정보 중첩 DTO)
    - `RegionDTO `(Vlock에 해당되는 지역 상세 정보 중첩 DTO)
- 예외 처리: 존재하지 않은 카테고리, 도시, 사용자 요청 시 적절한 에러 코드 반환

## 🧪 테스트 결과
[Postman Documents](https://documenter.getpostman.com/view/37268590/2sBXVmfTyr)
* 성공 케이스: `201 Created` 응답 및 생성된 데이터 반환 확인
* 실패 케이스: 잘못된 cityId 또는 categoryId 요청 시 `404 Not Found` 예외 발생 확인

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.
* AuthenticationPrincipal을 통해 로그인한 사용자의 Id를 가져오도록 구현했습니다.
* VlockService에서 City 조회 시 @EntityGraph를 활용하여 Region 정보도 함께 로딩되도록 고려했습니다.