### PR TITLE
[feat] #31 Rule-based 기반 템플릿 추천 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,12 @@ dependencies {
     runtimeOnly   'io.jsonwebtoken:jjwt-impl:0.12.5'
     runtimeOnly   'io.jsonwebtoken:jjwt-jackson:0.12.5'
     implementation 'com.resend:resend-java:3.1.0'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
@@ -2,6 +2,7 @@ package org.umc.travlocksserver.domain.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -11,6 +12,7 @@ import org.umc.travlocksserver.domain.member.dto.response.MemberNicknameExistsRe
 import org.umc.travlocksserver.domain.member.dto.response.MemberSignupResponseDTO;
 import org.umc.travlocksserver.global.response.SuccessResponse;
 
+@Tag(name = "템플릿 API", description = "템플릿 관련 API입니다.")
 public interface MemberControllerDocs {
 
     @Operation(

--- a/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.umc.travlocksserver.domain.template.dto.response.TemplateRecommendationsDTO;
 import org.umc.travlocksserver.domain.template.exception.code.TemplateSuccessCode;
-import org.umc.travlocksserver.domain.template.service.TemplateService;
+import org.umc.travlocksserver.domain.template.service.query.TemplateQueryService;
 import org.umc.travlocksserver.global.response.SuccessResponse;
 
 @RestController
@@ -16,13 +16,13 @@ import org.umc.travlocksserver.global.response.SuccessResponse;
 @RequiredArgsConstructor
 public class TemplateController implements TemplateControllerDocs {
 
-    private final TemplateService templateService;
+    private final TemplateQueryService templateQueryService;
 
     @GetMapping("/recommendations")
     public ResponseEntity<SuccessResponse<TemplateRecommendationsDTO>> getRecommendedTemplates(
             @AuthenticationPrincipal Long memberId
     ) {
-        TemplateRecommendationsDTO response = templateService.getRecommendedTemplates(memberId);
+        TemplateRecommendationsDTO response = templateQueryService.getRecommendedTemplates(memberId);
         return ResponseEntity.ok(SuccessResponse.ok(TemplateSuccessCode.TEMPLATE_RECOMMEND_SUCCESS, response));
     }
 }

--- a/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
@@ -1,0 +1,28 @@
+package org.umc.travlocksserver.domain.template.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.umc.travlocksserver.domain.template.dto.response.TemplateRecommendationsDTO;
+import org.umc.travlocksserver.domain.template.exception.code.TemplateSuccessCode;
+import org.umc.travlocksserver.domain.template.service.TemplateService;
+import org.umc.travlocksserver.global.response.SuccessResponse;
+
+@RestController
+@RequestMapping("/api/v1/templates")
+@RequiredArgsConstructor
+public class TemplateController implements TemplateControllerDocs {
+
+    private final TemplateService templateService;
+
+    @GetMapping("/recommendations")
+    public ResponseEntity<SuccessResponse<TemplateRecommendationsDTO>> getRecommendedTemplates(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        TemplateRecommendationsDTO response = templateService.getRecommendedTemplates(memberId);
+        return ResponseEntity.ok(SuccessResponse.ok(TemplateSuccessCode.TEMPLATE_RECOMMEND_SUCCESS, response));
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateControllerDocs.java
@@ -1,0 +1,22 @@
+package org.umc.travlocksserver.domain.template.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.umc.travlocksserver.domain.template.dto.response.TemplateRecommendationsDTO;
+import org.umc.travlocksserver.global.response.SuccessResponse;
+
+public interface TemplateControllerDocs {
+
+    @Operation(
+            summary = "AI 추천 템플릿 조회 API",
+            description = "Rule-based 방식으로 추천된 템플릿을 조회하는 API 입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "AI 템플릿 추천이 완료되었습니다.")
+    })
+    ResponseEntity<SuccessResponse<TemplateRecommendationsDTO>> getRecommendedTemplates(
+            @AuthenticationPrincipal Long memberId
+    );
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/dto/response/TemplateRecommendationCardDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/dto/response/TemplateRecommendationCardDTO.java
@@ -1,0 +1,18 @@
+package org.umc.travlocksserver.domain.template.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record TemplateRecommendationCardDTO(
+        Long templateId,
+        String coverImgUrl,
+        String title,
+        String description,
+        String region,
+        String tripDays,
+        String tripTheme,
+        Double totalScore
+) {
+    @QueryProjection
+    public TemplateRecommendationCardDTO {
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/dto/response/TemplateRecommendationsDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/dto/response/TemplateRecommendationsDTO.java
@@ -5,10 +5,9 @@ import org.umc.travlocksserver.infra.redis.template.CachedTemplateRecommendation
 import java.util.List;
 
 public record TemplateRecommendationsDTO(
-        String recommendationId,
         List<TemplateRecommendationCardDTO> templates
 ) {
     public static TemplateRecommendationsDTO from(CachedTemplateRecommendations cached) {
-        return new TemplateRecommendationsDTO(cached.recommendationId(), cached.templates());
+        return new TemplateRecommendationsDTO(cached.templates());
     }
 }

--- a/src/main/java/org/umc/travlocksserver/domain/template/dto/response/TemplateRecommendationsDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/dto/response/TemplateRecommendationsDTO.java
@@ -1,0 +1,14 @@
+package org.umc.travlocksserver.domain.template.dto.response;
+
+import org.umc.travlocksserver.infra.redis.template.CachedTemplateRecommendations;
+
+import java.util.List;
+
+public record TemplateRecommendationsDTO(
+        String recommendationId,
+        List<TemplateRecommendationCardDTO> templates
+) {
+    public static TemplateRecommendationsDTO from(CachedTemplateRecommendations cached) {
+        return new TemplateRecommendationsDTO(cached.recommendationId(), cached.templates());
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/entity/TemplateTag.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/entity/TemplateTag.java
@@ -25,8 +25,8 @@ public class TemplateTag extends CreatedBaseEntity {
     @JoinColumn(name = "template_id", nullable = false)
     private Template template;
 
-    @Column(name = "rank", nullable = false)
-    private Integer rank;
+    @Column(name = "ranking", nullable = false)
+    private Integer ranking;
 
     @Column(name = "confidence", nullable = false)
     private Double confidence;

--- a/src/main/java/org/umc/travlocksserver/domain/template/exception/code/TemplateSuccessCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/exception/code/TemplateSuccessCode.java
@@ -1,0 +1,19 @@
+package org.umc.travlocksserver.domain.template.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.umc.travlocksserver.global.code.BaseCode;
+
+@AllArgsConstructor
+@Getter
+public enum TemplateSuccessCode implements BaseCode {
+    TEMPLATE_RECOMMEND_SUCCESS(
+            HttpStatus.OK,
+            "AI 템플릿 추천이 완료되었습니다."
+    )
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateRepository.java
@@ -1,0 +1,30 @@
+package org.umc.travlocksserver.domain.template.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.umc.travlocksserver.domain.template.entity.Template;
+
+import java.util.List;
+
+@Repository
+public interface TemplateRepository extends JpaRepository<Template, Long>, TemplateRepositoryCustom {
+
+    @Query("""
+        SELECT DISTINCT t.parentTemplate.id
+        FROM Template t
+        WHERE t.owner.id = :memberId
+            AND t.parentTemplate IS NOT NULL
+    """)
+    List<Long> findRemixedTemplateIdsByMemberId(@Param("memberId") Long memberId);
+
+    @Query("""
+        SELECT t.travelTheme.id
+        FROM Template t
+        WHERE t.owner.id = :memberId
+        ORDER BY t.updatedAt DESC
+    """)
+    List<Long> findRecentThemeIdsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateRepositoryCustom.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateRepositoryCustom.java
@@ -1,0 +1,15 @@
+package org.umc.travlocksserver.domain.template.repository;
+
+import org.umc.travlocksserver.domain.template.dto.response.TemplateRecommendationCardDTO;
+
+import java.util.List;
+
+public interface TemplateRepositoryCustom {
+
+    List<TemplateRecommendationCardDTO> recommendPersonalized(
+            List<Long> preferredThemeIds,
+            List<Long> recentThemeIds,
+            List<Long> excludedTemplateIds,
+            int limit
+    );
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateRepositoryCustomImpl.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateRepositoryCustomImpl.java
@@ -1,0 +1,145 @@
+package org.umc.travlocksserver.domain.template.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.umc.travlocksserver.domain.location.entity.QCity;
+import org.umc.travlocksserver.domain.location.entity.QRegion;
+import org.umc.travlocksserver.domain.template.dto.response.QTemplateRecommendationCardDTO;
+import org.umc.travlocksserver.domain.template.dto.response.TemplateRecommendationCardDTO;
+import org.umc.travlocksserver.domain.template.entity.QTemplate;
+import org.umc.travlocksserver.domain.template.entity.QTemplateCity;
+import org.umc.travlocksserver.domain.traveltheme.entity.QTravelTheme;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TemplateRepositoryCustomImpl implements TemplateRepositoryCustom {
+    private static final int PREFERRED_THEME_BONUS = 30;
+    private static final int RECENT_THEME_BONUS = 20;
+    private static final double RATING_WEIGHT = 5.0;  // 평점은 5점 만점이므로 5 * 5 = 최대 25점
+    private static final double REMIX_WEIGHT = 15.0;
+    private static final double FAVORITE_WEIGHT = 10.0;
+
+    private final JPAQueryFactory query;
+
+    /**
+    * 개인화된 템플릿 추천 목록 조회
+    * 점수 계산:
+    * - 선호 테마 일치: + 30점
+    * - 최근 수정한 템플릿의 테마와 일치: + 20점
+    * - 평점: 0~25점 (가중치 5)
+    * - 리믹스 점수: 0~30점 (가중치 15)
+    * - 즐겨찾기 점수: 0~10점 (가중치 10)
+    */
+    public List<TemplateRecommendationCardDTO> recommendPersonalized(
+            List<Long> preferredThemeIds,
+            List<Long> recentThemeIds,
+            List<Long> excludedTemplateIds,
+            int limit
+    ) {
+        QTemplate t = QTemplate.template;
+        QTravelTheme tt= QTravelTheme.travelTheme;
+        QCity c = QCity.city;
+        QTemplateCity tc = QTemplateCity.templateCity;
+        QTemplateCity tc2 = new QTemplateCity("tc2");
+        QRegion r = QRegion.region;
+
+        JPQLQuery<Long> firstTcIdOfTemplate = getFirstTcIdOfTemplate(t, tc2);
+        BooleanBuilder builder = buildCondition(t, excludedTemplateIds);
+        NumberExpression<Double> totalScore = calculateTotalScore(t, preferredThemeIds, recentThemeIds);
+
+        return query
+                .select(new QTemplateRecommendationCardDTO(
+                        t.id,
+                        t.coverImageUrl,
+                        t.title,
+                        t.description,
+                        r.name,
+                        t.tripDays,
+                        tt.content,
+                        totalScore
+                ))
+                .from(t)
+                .join(t.travelTheme, tt)
+                .leftJoin(tc).on(tc.id.eq(firstTcIdOfTemplate))  // 대표 template_city_id로 left join
+                .leftJoin(tc.city, c)
+                .leftJoin(c.region, r)  // city에서 region을 추출해내기 위한 join
+                .where(builder)
+                .orderBy(totalScore.desc(), t.id.desc())
+                .limit(limit)
+                .fetch();
+
+    }
+
+    // 템플릿의 city들 중 가장 작은 id 조회 (대표도시)
+    private JPQLQuery<Long> getFirstTcIdOfTemplate(QTemplate t, QTemplateCity tc) {
+        return JPAExpressions
+                .select(tc.id.min())
+                .from(tc)
+                .where(tc.template.id.eq(t.id));
+    }
+
+    // 조건식 설계 (공개 & 리믹스한 적 없는 템플릿만)
+    private BooleanBuilder buildCondition(QTemplate t, List<Long> excludedTemplateIds) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(t.isPublic.isTrue());
+
+        if (!excludedTemplateIds.isEmpty()) {
+            builder.and(t.id.notIn(excludedTemplateIds));
+        }
+
+        return builder;
+    }
+
+    // 점수 계산
+    private NumberExpression<Double> calculateTotalScore(
+            QTemplate t,
+            List<Long> preferredThemeIds,
+            List<Long> recentThemeIds
+    ) {
+        NumberExpression<Integer> preferredBonus = calculatePreferredBonus(t, preferredThemeIds);
+        NumberExpression<Integer> recentBonus = calculateRecentBonus(t, recentThemeIds);
+
+        NumberExpression<Double> ratingScore = t.avgRating.coalesce(0.0).multiply(RATING_WEIGHT);
+        NumberExpression<Double> remixScore = log10(t.remixCount.coalesce(0).add(1).doubleValue()).multiply(REMIX_WEIGHT);
+        NumberExpression<Double> favoriteScore = log10(t.favoriteCount.coalesce(0).add(1).doubleValue()).multiply(FAVORITE_WEIGHT);
+
+        return preferredBonus.add(recentBonus).doubleValue()
+                .add(ratingScore)
+                .add(remixScore)
+                .add(favoriteScore);
+    }
+
+    // 선호 테마와 일치하는 템플릿에 가점
+    private NumberExpression<Integer> calculatePreferredBonus(QTemplate t, List<Long> preferredThemeIds) {
+        return preferredThemeIds.isEmpty()
+                ? Expressions.ZERO
+                : new CaseBuilder()
+                .when(t.travelTheme.id.in(preferredThemeIds))
+                .then(PREFERRED_THEME_BONUS)
+                .otherwise(0);
+    }
+
+    // 최근 수정한 템플릿 테마와 일치하는 템플릿에 가점
+    private NumberExpression<Integer> calculateRecentBonus(QTemplate t, List<Long> recentThemeIds) {
+        return recentThemeIds.isEmpty()
+                ? Expressions.ZERO
+                : new CaseBuilder()
+                .when(t.travelTheme.id.in(recentThemeIds))
+                .then(RECENT_THEME_BONUS)
+                .otherwise(0);
+    }
+
+    // 점수 보정을 위한 log 메서드
+    private NumberExpression<Double> log10(NumberExpression<Double> expression) {
+        return Expressions.numberTemplate(Double.class, "LOG10({0})", expression);
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/service/TemplateService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/service/TemplateService.java
@@ -1,0 +1,62 @@
+package org.umc.travlocksserver.domain.template.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.umc.travlocksserver.domain.template.dto.response.TemplateRecommendationCardDTO;
+import org.umc.travlocksserver.domain.template.dto.response.TemplateRecommendationsDTO;
+import org.umc.travlocksserver.domain.template.repository.TemplateRepository;
+import org.umc.travlocksserver.domain.traveltheme.repository.PreferredTravelThemeRepository;
+import org.umc.travlocksserver.infra.redis.template.CachedTemplateRecommendations;
+import org.umc.travlocksserver.infra.redis.template.TemplateRecommendationCache;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class TemplateService {
+
+    private static final int RECENT_TEMPLATE_LIMIT = 5;
+    private static final int RECOMMEND_TEMPLATE_LIMIT = 10;
+
+    private final TemplateRecommendationCache cache;
+    private final PreferredTravelThemeRepository preferredTravelThemeRepository;
+    private final TemplateRepository templateRepository;
+
+    public TemplateRecommendationsDTO getRecommendedTemplates(Long memberId) {
+        CachedTemplateRecommendations cached = cache.get(memberId);
+
+        // Cache hit -> Caching된 추천 리스트 반환
+        if (cached != null) {
+            log.info("캐싱된 데이터 반환");
+            return TemplateRecommendationsDTO.from(cached);
+        }
+
+        // Cache miss -> 추천
+        log.info("새로운 추천 데이터 생성");
+        List<TemplateRecommendationCardDTO> templates = recommendTemplates(memberId);
+        CachedTemplateRecommendations recommendedTemplates = CachedTemplateRecommendations.from(templates);
+        cache.set(memberId, recommendedTemplates);
+        return TemplateRecommendationsDTO.from(recommendedTemplates);
+    }
+
+    private List<TemplateRecommendationCardDTO> recommendTemplates(Long memberId) {
+       // 회원 선호 테마 ID들 조회
+        List<Long> preferredThemeIds = preferredTravelThemeRepository.findPreferredThemeIdsByMemberId(memberId);
+
+        // 최근 5개 템플릿의 TravleThemeID 뽑고 Distinct
+        List<Long> recentThemeIds = templateRepository.findRecentThemeIdsByMemberId(memberId, PageRequest.of(0, RECENT_TEMPLATE_LIMIT));
+
+        // 이미 리믹스한 템플릿 ID들 조회 (추천에서 제외하기 위함)
+        List<Long> excludedTemplateIds = templateRepository.findRemixedTemplateIdsByMemberId(memberId);
+
+        // 개인화 추천
+        List<TemplateRecommendationCardDTO> result = templateRepository.recommendPersonalized(preferredThemeIds, recentThemeIds,excludedTemplateIds, RECOMMEND_TEMPLATE_LIMIT);
+
+        return result;
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/service/query/TemplateQueryService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/service/query/TemplateQueryService.java
@@ -1,4 +1,4 @@
-package org.umc.travlocksserver.domain.template.service;
+package org.umc.travlocksserver.domain.template.service.query;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Slf4j
-public class TemplateService {
+public class TemplateQueryService {
 
     private static final int RECENT_TEMPLATE_LIMIT = 5;
     private static final int RECOMMEND_TEMPLATE_LIMIT = 10;

--- a/src/main/java/org/umc/travlocksserver/domain/traveltheme/repository/PreferredTravelThemeRepository.java
+++ b/src/main/java/org/umc/travlocksserver/domain/traveltheme/repository/PreferredTravelThemeRepository.java
@@ -1,6 +1,18 @@
 package org.umc.travlocksserver.domain.traveltheme.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.umc.travlocksserver.domain.traveltheme.entity.PreferredTravelTheme;
 
-public interface PreferredTravelThemeRepository extends JpaRepository<PreferredTravelTheme, Long> {}
+import java.util.List;
+
+public interface PreferredTravelThemeRepository extends JpaRepository<PreferredTravelTheme, Long> {
+
+    @Query("""
+        SELECT ptt.travelTheme.id
+        FROM PreferredTravelTheme ptt
+        WHERE ptt.member.id = :memberId
+    """)
+    List<Long> findPreferredThemeIdsByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/org/umc/travlocksserver/global/config/QuerydslConfig.java
+++ b/src/main/java/org/umc/travlocksserver/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package org.umc.travlocksserver.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/global/config/RedisConfig.java
+++ b/src/main/java/org/umc/travlocksserver/global/config/RedisConfig.java
@@ -1,0 +1,44 @@
+package org.umc.travlocksserver.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+// ✨ Spring에서 Redis에 저장되는 값을 사람이 읽을 수 있는 JSON으로 저장하도록 만드는 클래스
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(
+            RedisConnectionFactory connectionFactory,
+            ObjectMapper objectMapper
+    ) {
+        ObjectMapper mapper = objectMapper.copy()  // Redis 전용 복사본을 만들어서 Redis 직렬화 옵션을 바꿔도 API JSON 응답에는 영향주지 않음
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        StringRedisSerializer string = new StringRedisSerializer();
+        GenericJackson2JsonRedisSerializer json = new GenericJackson2JsonRedisSerializer(mapper);
+
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(string);  // Redis key를 사람이 읽는 문자열로 저장
+        template.setValueSerializer(json);  // Redis value를 JSON 문자열로 저장
+
+        template.setHashKeySerializer(string);
+        template.setHashValueSerializer(json);
+
+        template.setDefaultSerializer(json);
+
+        template.afterPropertiesSet();
+
+        return template;
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/infra/redis/template/CachedTemplateRecommendations.java
+++ b/src/main/java/org/umc/travlocksserver/infra/redis/template/CachedTemplateRecommendations.java
@@ -1,0 +1,17 @@
+package org.umc.travlocksserver.infra.redis.template;
+
+import org.umc.travlocksserver.domain.template.dto.response.TemplateRecommendationCardDTO;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CachedTemplateRecommendations(
+        String recommendationId,
+        List<TemplateRecommendationCardDTO>  templates
+) {
+    public static CachedTemplateRecommendations from(List<TemplateRecommendationCardDTO> templates) {
+        return new CachedTemplateRecommendations(
+                UUID.randomUUID().toString(), templates
+        );
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/infra/redis/template/CachedTemplateRecommendations.java
+++ b/src/main/java/org/umc/travlocksserver/infra/redis/template/CachedTemplateRecommendations.java
@@ -6,12 +6,9 @@ import java.util.List;
 import java.util.UUID;
 
 public record CachedTemplateRecommendations(
-        String recommendationId,
         List<TemplateRecommendationCardDTO>  templates
 ) {
     public static CachedTemplateRecommendations from(List<TemplateRecommendationCardDTO> templates) {
-        return new CachedTemplateRecommendations(
-                UUID.randomUUID().toString(), templates
-        );
+        return new CachedTemplateRecommendations(templates);
     }
 }

--- a/src/main/java/org/umc/travlocksserver/infra/redis/template/TemplateRecommendationCache.java
+++ b/src/main/java/org/umc/travlocksserver/infra/redis/template/TemplateRecommendationCache.java
@@ -1,0 +1,36 @@
+package org.umc.travlocksserver.infra.redis.template;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class TemplateRecommendationCache {
+
+    private final RedisTemplate<String, Object> redis;
+    private final ObjectMapper objectMapper;
+
+    @Value("${cache.recommendation.templates.cache-ttl-minutes}")
+    private long ttlMinutes;
+
+    public CachedTemplateRecommendations get(Long memberId) {
+        Object object = redis.opsForValue().get(key(memberId));
+        if (object == null) {
+            return null;
+        }
+        return objectMapper.convertValue(object, CachedTemplateRecommendations.class);
+    }
+
+    public void set(Long memberId, CachedTemplateRecommendations value) {
+        redis.opsForValue().set(key(memberId), value, Duration.ofMinutes(ttlMinutes));
+    }
+
+    private String key(Long memberId) {
+        return "recommendation:templates:v1:member:" + memberId;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,3 +44,8 @@ springdoc:
     enabled: true
   swagger-ui:
     enabled: true
+
+cache:
+  recommendation:
+    templates:
+      cache-ttl-minutes: 15


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #31

## 📌 작업 내용
> Rule-based 기반 템플릿 추천 API를 구현했습니다.

현재 MVP 단계에서 LLM 기반 추천은 데이터 양적으로, 설계적으로도 어려움이 있다고 판단했고,  
PM님과 논의하여 Rule-based 기반 추천 방식을 이용했습니다. 추천 방식에 대한 비교는 아래 토글 참고 부탁드립니다.
<details>
  <summary><b>추천 방식 비교</b></summary>
  <div markdown="1">
    <ul>

1. **프롬프트 기반 추천**
    
     가장 처음에는 서버의 템플릿 정보를 프롬프트로 LLM에 전달한 후 LLM이 추천 템플릿을 선별하는 방식을 생각했습니다. 하지만 이 방식은 초기에 템플릿 수가 적으면 가능할지 몰라도 아래와 같은 한계로 핵심 추천 로직으로 사용하기에는 어렵다고 판단했습니다.
    
    1. **문제점**
    - 토큰 제한 문제
        - 템플릿 수가 증가하면 모든 후보를 프롬프트에 포함할 수 없음
    - 비용 및 응답 시간 증가
        - 템플릿 수에 비례하여 비용과 지연 시간이 증가
2. **Embedding 기반 추천**
    1. **장점**
        - 대규모 템플릿에서도 확장 가능
        - 템플릿과 사용자 조건을 벡터화하여 의미적 유사성 기반 검색 및 추천 가능
    2. **문제점**
        - MVP 단계에서 추천 품질을 보장할 만큼의 템플릿/행동 데이터 부족
        - Vector DB 도입 및 운영 비용 증가
        - MVP 단계에서는 과도한 설계라 판단
    
    하지만 현재 데이터가 없는 상황에서 embedding 도입은 효과 대비 복잡도가 크다고 판단했습니다.
    
3. **Rule-based 추천**
    
     따라서 앞서 언급된 방식들의 장점과 한계점을 고려하여 MVP 단계에서는 Rule-based 추천 방식을 도입하기로 결정했습니다.
    
    1. **선택 이유**
    - 데이터가 부족해도 동작
    - 추천 기준이 명확하고 통제 가능

    </ul>
  </div>
</details>

### 1. QueryDSL 도입
- Rule-based 기반 추천을 하게 되면서 조회 시 점수 계산 등 복잡한 조회 로직이 수반되어 기존에 논의했던대로 QueryDSL를 도입했습니다.
- 또한 QueryProjection을 이용하여 필요한 결과만 QueryDSL에서 반환하도록 했습니다.

### 2. Redis 도입
- 정책집을 참고하여, 추천된 결과는 일정 시간동안 같은 결과가 조회되고 일정 시간 후 새로운 추천 결과를 반환받는다는 점에서 캐싱이 필요하다고 생각해 도입했습니다.
- 일정 기간은 제가 임의로 15분으로 해두었는데, 다른 좋은 값이 있을 경우 수정해도 좋을 것 같습니다.

### 3. 점수 계산 로직
점수 계산 로직은 정책집을 참고해 아래와 같이 계산하도록 했습니다.
- 선호 테마 일치: + 30점
- 최근 수정한 템플릿의 테마와 일치: + 20점
- 평점: 0~25점 (가중치 5)
- 리믹스 점수: 0~30점 (가중치 15)
- 즐겨찾기 점수: 0~10점 (가중치 10)

이때 리믹스 수와 즐겨찾기 수는 일정 수 이상 커지게 되면 점수 계산에 미치는 영향이 과할 것이라고 판단해 
log을 통해 점수를 보정하도록 했습니다.

추가적으로 추천된 템플릿들의 점수가 궁금하실 수도 있을 것 같아 우선 응답에 totalScore를 포함하도록 했습니다. 


### 4. Redis 관련 파일 위치
- Redis 관련 파일(CachedTemplateRecommendations, TemplateRecommendationCache)는 도메인과 별도로 디렉토리 구분이 필요하다고 생각했습니다. 
- Redis는 기술 구현체라고 생각해 우선 /infra/redis 하위의 template 디렉토리 내에 관련 파일들을 넣어놨습니다.

### 5. TemplateTag 엔티티 rank -> ranking 컬럼명 변경
- 추가적으로 TemplateTag 엔티티에 있는 rank 컬럼명이 MySQL 함수명과 일치하여 문제가 발생할 수 있겠다는 생각을 했습니다. 
- 따라서 컬럼명을 ranking으로 변경해주었습니다.



## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
1. Swagger 응답 조회 테스트
<img width="968" height="640" alt="image" src="https://github.com/user-attachments/assets/fe81c38f-63b9-42e4-9d70-ccad1aa69ce5" />

2. log.info를 통한 캐싱된 데이터 반환 여부 테스트
(1) 새로운 추천 데이터를 생성한 경우
<img width="548" height="88" alt="image" src="https://github.com/user-attachments/assets/4d0b8f04-f027-472a-a71a-b74486b763fb" />

(2) 캐싱된 데이터를 반환한 경우
<img width="570" height="94" alt="image" src="https://github.com/user-attachments/assets/86365cd0-255f-4992-94b6-798c6abfdf00" />

3. Redis MONITOR를 통한 테스트
아래와 같이 API 호출 시 Redis에 요청이 가는 것을 확인했으며, 데이터가 저장된 것도 확인할 수 있었습니다.
<img width="1280" height="103" alt="image" src="https://github.com/user-attachments/assets/4fd6bbb3-cc12-4dd2-a4fd-b3363f1892e8" />




## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 
1. QueryDSL 로직이 좀 지저분한데... 혹시 다른 좋은 방안 있으시면 리뷰 부탁드려요!!
2. 조회 성능을 위해 인덱스 도입이 필요하다고 생각합니다. 이는 추후 데이터 추가한 뒤 속도 체크 후 추가해보도록 하겠습니다!
3. 사실.. 
15분 뒤 새로고침하면 다른 템플릿들이 추천되는 것이 맞는데, 
현실적으로 해당 템플릿의 즐겨찾기, 리믹스 수 등에 큰 변화가 있어야 결과도 변화가 있을 것 같습니다. 
Redis를 활용해서 이미 추천된 건 일정 기간 제외하고 추천 결과를 반환하는 방법도 고려해봤지만, 
MVP 단계에서 "적은 데이터 수 + 이미 리믹스한 템플릿 제외 + 이미 추천된 템플릿 제외" 를 고려하면 
정책집에서 언급된 "무조건 노출"에 어려움이 있을 것 같아 
추후 확장에서 이미 추천된 건 일정 기간 제외하고 추천 결과를 반환을 고려하는 것이 좋다고 판단했습니다.
