### PR TITLE
[refactor] #46 Swagger OpenAPI 서버 URL 설정

### DIFF
--- a/src/main/java/org/umc/travlocksserver/global/config/SwaggerConfig.java
+++ b/src/main/java/org/umc/travlocksserver/global/config/SwaggerConfig.java
@@ -1,5 +1,6 @@
 package org.umc.travlocksserver.global.config;
 
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,18 +10,23 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 
+import java.util.List;
+
 @Configuration
 public class SwaggerConfig {
 
 	private static final String JWT_SCHEME_NAME = "JWT";
 
-	@Bean
-	public OpenAPI openAPI() {
-		return new OpenAPI()
-			.info(apiInfo())
-			.components(components())
-			.addSecurityItem(new SecurityRequirement().addList(JWT_SCHEME_NAME));
-	}
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(apiInfo())
+                .servers(List.of(
+                        new Server().url("https://api.travlocks.kro.kr")
+                ))
+                .components(components())
+                .addSecurityItem(new SecurityRequirement().addList(JWT_SCHEME_NAME));
+    }
 
 	private Info apiInfo() {
 		return new Info()


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #46 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- Swagger UI에서 기본 서버 URL이 명확하게 지정되지 않아, 요청이 의도하지 않은 base URL로 전송되는 문제가 발생했습니다.

- 이를 해결하기 위해 OpenAPI 설정에 `https://api.travlocks.kro.kr` 서버 URL로 명시하여  
   Swagger 요청이 항상 올바른 서버를 기준으로 수행되도록 수정했습니다.


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
- `new Server().url("http://localhost:8080")`를 기준으로  
  `http://localhost:8080/swagger-ui/index.html#/`에서 테스트 시,
  기존에 발생하던 `Failed to fetch` 오류가 발생하지 않고 정상 동작함을 확인했습니다.
- 이후 실제 사용 환경에 맞게,
  Swagger는 `https://travlocks.kro.kr/swagger-ui/index.html#/`에서 사용되므로  
  server URL을 `https://api.travlocks.kro.kr`로 변경했습니다.

- 아래 오류 해결
<img width="1184" height="482" alt="image" src="https://github.com/user-attachments/assets/d1453e09-74dd-4b17-a0b8-b10cc7836189" />

- 정상 동작 확인
<img width="1042" height="494" alt="image" src="https://github.com/user-attachments/assets/1c9fe5b9-0a4d-42ad-9efd-5d86ca83bac6" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.