### PR TITLE
[feat] #52 회원가입 시 자동 프로필 설정 및 토큰 발급

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package org.umc.travlocksserver.domain.auth.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.umc.travlocksserver.domain.auth.dto.request.AuthLoginRequestDTO;
 import org.umc.travlocksserver.domain.auth.dto.request.AuthResendEmailRequestDTO;
@@ -28,45 +29,64 @@ public class AuthController implements AuthControllerDocs {
     private final AuthService authService;
 
 	@PostMapping("/email-verification")
-	public SuccessResponse<AuthSendEmailResponseDTO> sendEmailVerificationCode(
+	public ResponseEntity<SuccessResponse<AuthSendEmailResponseDTO>> sendEmailVerificationCode(
 		@Valid @RequestBody
 		AuthSendEmailRequestDTO request) {
-		AuthSendEmailResponseDTO data = emailVerificationService.sendVerificationCode(request.email());
+        AuthSuccessCode successCode = AuthSuccessCode.EMAIL_VERIFICATION_CODE_SENT;
+        AuthSendEmailResponseDTO data = emailVerificationService.sendVerificationCode(request.email());
 
-		return SuccessResponse.ok(AuthSuccessCode.EMAIL_VERIFICATION_CODE_SENT, data);
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.ok(successCode, data));
 	}
 
 	@PostMapping("/email-verification/confirm")
-	public SuccessResponse<AuthVerifyEmailResponseDTO> confirmEmailVerificationCode(
+	public ResponseEntity<SuccessResponse<AuthVerifyEmailResponseDTO>> confirmEmailVerificationCode(
 		@Valid @RequestBody
 		AuthVerifyEmailRequestDTO request) {
+        AuthSuccessCode successCode = AuthSuccessCode.EMAIL_VERIFICATION_CONFIRMED;
 		AuthVerifyEmailResponseDTO data = emailVerificationService.confirmVerificationCode(
 			request.verificationId(),
-			request.code());
+			request.code()
+        );
 
-		return SuccessResponse.ok(AuthSuccessCode.EMAIL_VERIFICATION_CONFIRMED, data);
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.ok(successCode, data));
 	}
 
 	@PostMapping("/email-verification/resend")
-	public SuccessResponse<?> resendEmailVerificationCode(
+	public ResponseEntity<SuccessResponse<?>> resendEmailVerificationCode(
 		@Valid @RequestBody
 		AuthResendEmailRequestDTO request) {
+        AuthSuccessCode successCode = AuthSuccessCode.EMAIL_VERIFICATION_CODE_RESENT;
 		emailVerificationService.resendVerificationCode(request.verificationId());
-		return SuccessResponse.ok(AuthSuccessCode.EMAIL_VERIFICATION_CODE_RESENT);
+
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.ok(successCode, null));
 	}
 
     @PostMapping("/login")
-    public SuccessResponse<AuthLoginResponseDTO> login(
+    public ResponseEntity<SuccessResponse<AuthLoginResponseDTO>> login(
             @Valid @RequestBody AuthLoginRequestDTO request,
             HttpServletResponse response) {
+        AuthSuccessCode successCode = AuthSuccessCode.AUTH_LOGIN_SUCCESS;
         AuthLoginResponseDTO data = authService.login(request, response);
-        return SuccessResponse.ok(AuthSuccessCode.AUTH_LOGIN_SUCCESS, data);
+
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.ok(successCode, data));
     }
 
     @PostMapping("/refresh")
-    public SuccessResponse<AuthRefreshResponseDTO> refresh(
+    public ResponseEntity<SuccessResponse<AuthRefreshResponseDTO>> refresh(
             HttpServletRequest request) {
+        AuthSuccessCode successCode = AuthSuccessCode.AUTH_ACCESS_TOKEN_REISSUED;
         AuthRefreshResponseDTO data = authService.refreshAccessToken(request);
-        return SuccessResponse.ok(AuthSuccessCode.AUTH_ACCESS_TOKEN_REISSUED, data);
+
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.ok(successCode, data));
     }
 }

--- a/src/main/java/org/umc/travlocksserver/domain/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/controller/AuthControllerDocs.java
@@ -2,10 +2,13 @@ package org.umc.travlocksserver.domain.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
 import org.umc.travlocksserver.domain.auth.dto.request.AuthLoginRequestDTO;
 import org.umc.travlocksserver.domain.auth.dto.request.AuthResendEmailRequestDTO;
 import org.umc.travlocksserver.domain.auth.dto.request.AuthSendEmailRequestDTO;
@@ -14,6 +17,7 @@ import org.umc.travlocksserver.domain.auth.dto.response.AuthLoginResponseDTO;
 import org.umc.travlocksserver.domain.auth.dto.response.AuthRefreshResponseDTO;
 import org.umc.travlocksserver.domain.auth.dto.response.AuthSendEmailResponseDTO;
 import org.umc.travlocksserver.domain.auth.dto.response.AuthVerifyEmailResponseDTO;
+import org.umc.travlocksserver.global.response.ErrorResponse;
 import org.umc.travlocksserver.global.response.SuccessResponse;
 
 public interface AuthControllerDocs {
@@ -29,10 +33,10 @@ public interface AuthControllerDocs {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이메일 인증 코드 발송 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / 이미 가입된 이메일 / 인증 요청 정보 오류"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "이메일 발송 실패")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / 이미 가입된 이메일 / 인증 요청 정보 오류",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "이메일 발송 실패",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    SuccessResponse<AuthSendEmailResponseDTO> sendEmailVerificationCode(
+    ResponseEntity<SuccessResponse<AuthSendEmailResponseDTO>> sendEmailVerificationCode(
             @Valid AuthSendEmailRequestDTO request
     );
 
@@ -49,9 +53,9 @@ public interface AuthControllerDocs {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이메일 인증 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / verificationId 만료·없음 / 인증 코드 불일치")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / verificationId 만료·없음 / 인증 코드 불일치",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    SuccessResponse<AuthVerifyEmailResponseDTO> confirmEmailVerificationCode(
+    ResponseEntity<SuccessResponse<AuthVerifyEmailResponseDTO>> confirmEmailVerificationCode(
             @Valid AuthVerifyEmailRequestDTO request
     );
 
@@ -66,10 +70,10 @@ public interface AuthControllerDocs {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이메일 인증 코드 재발송 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / verificationId 만료·없음"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "이메일 발송 실패")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / verificationId 만료·없음",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "이메일 발송 실패",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    SuccessResponse<?> resendEmailVerificationCode(
+    ResponseEntity<SuccessResponse<?>> resendEmailVerificationCode(
             @Valid AuthResendEmailRequestDTO request
     );
 
@@ -84,10 +88,10 @@ public interface AuthControllerDocs {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인 실패(이메일 또는 비밀번호 불일치)")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인 실패(이메일 또는 비밀번호 불일치)",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    SuccessResponse<AuthLoginResponseDTO> login(
+    ResponseEntity<SuccessResponse<AuthLoginResponseDTO>> login(
             @Valid AuthLoginRequestDTO request,
             @Parameter(hidden = true) HttpServletResponse response
     );
@@ -103,9 +107,9 @@ public interface AuthControllerDocs {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "액세스 토큰 재발급 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "refreshToken 누락 / 유효하지 않음 / 만료됨")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "refreshToken 누락 / 유효하지 않음 / 만료됨",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    SuccessResponse<AuthRefreshResponseDTO> refresh(
+    ResponseEntity<SuccessResponse<AuthRefreshResponseDTO>> refresh(
             @Parameter(hidden = true) HttpServletRequest request
     );
 }

--- a/src/main/java/org/umc/travlocksserver/domain/auth/service/command/AuthService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/service/command/AuthService.java
@@ -34,45 +34,25 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
-    public AuthLoginResponseDTO login(AuthLoginRequestDTO request, HttpServletResponse response) {
-        Duration refreshTtl = Duration.ofSeconds(refreshTtlSeconds);
+    public record IssuedTokens(String accessToken, long accessTokenExpiresIn) {
+    }
 
-        // 1) 회원 조회
+    public AuthLoginResponseDTO login(AuthLoginRequestDTO request, HttpServletResponse response) {
+        // 회원 조회
         Member member = memberRepository.findByEmail(request.email())
                 .orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_CREDENTIALS));
 
-        // 2) 비밀번호 검증
+        // 비밀번호 검증
         if (!passwordEncoder.matches(request.password(), member.getPasswordHash())) {
             throw new AuthException(AuthErrorCode.INVALID_CREDENTIALS);
         }
-        
-        // 3) 토큰 생성
-        // AccessToken
-        String accessToken = jwtTokenProvider.generateAccessToken(member.getId());
 
-        // RefreshToken (jti 포함)
-        String jti = UUID.randomUUID().toString();
-        String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId(), jti);
+        IssuedTokens tokens = issueTokens(member.getId(), response);
 
-        // 4) refreshToken -> Redis 저장
-        refreshTokenRedisRepository.save(jti, member.getId(), refreshTtl);
-
-        // 5) refreshToken -> Set-Cookie
-        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
-                .httpOnly(true)
-                .secure(false) // 운영환경에선 true로 변경
-                .path("/api/v1/auth/refresh")
-                .maxAge(refreshTtl)
-                .sameSite("Lax") // 운영환경에선 None으로 변경
-                .build();
-
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-
-        // 6) Response Body
         return new AuthLoginResponseDTO(
                 member.getId(),
-                accessToken,
-                jwtTokenProvider.getAccessTokenExpiresInSeconds()
+                tokens.accessToken(),
+                tokens.accessTokenExpiresIn()
         );
     }
 
@@ -114,6 +94,34 @@ public class AuthService {
                 newAccessToken,
                 jwtTokenProvider.getAccessTokenExpiresInSeconds()
         );
+    }
+
+    // AccessToken, RefreshToken 발급
+    public IssuedTokens issueTokens(Long memberId, HttpServletResponse response) {
+        Duration refreshTtl = Duration.ofSeconds(refreshTtlSeconds);
+
+        // AccessToken
+        String accessToken = jwtTokenProvider.generateAccessToken(memberId);
+
+        // RefreshToken (jti 포함)
+        String jti = UUID.randomUUID().toString();
+        String refreshToken = jwtTokenProvider.generateRefreshToken(memberId, jti);
+
+        // refreshToken -> Redis 저장
+        refreshTokenRedisRepository.save(jti, memberId, refreshTtl);
+
+        // refreshToken -> Set-Cookie
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(false) // 운영환경에선 true로 변경
+                .path("/")
+                .maxAge(refreshTtl)
+                .sameSite("Lax") // 운영환경에선 None으로 변경
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return new IssuedTokens(accessToken, jwtTokenProvider.getAccessTokenExpiresInSeconds());
     }
 
     private String extractRefreshTokenFromCookie(HttpServletRequest request) {

--- a/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberController.java
@@ -33,53 +33,62 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/members")
 public class MemberController implements MemberControllerDocs {
 
-	private final MemberEmailCheckService memberEmailCheckService;
-	private final MemberNicknameCheckService memberNicknameCheckService;
-	private final MemberSignupService memberSignupService;
-	private final MemberProfileQueryService memberProfileQueryService;
+    private final MemberEmailCheckService memberEmailCheckService;
+    private final MemberNicknameCheckService memberNicknameCheckService;
+    private final MemberSignupService memberSignupService;
+    private final MemberProfileQueryService memberProfileQueryService;
 
-	@GetMapping("/email/exists")
-	public SuccessResponse<MemberEmailExistsResponseDTO> checkEmailExists(
-		@RequestParam
-		@NotBlank(message = "이메일은 필수입니다.") @Email(message = "올바르지 않은 이메일 형식입니다.")
-		String email) {
-		MemberEmailExistsResponseDTO data = memberEmailCheckService.checkEmailExists(email);
+    @GetMapping("/email/exists")
+    public ResponseEntity<SuccessResponse<MemberEmailExistsResponseDTO>> checkEmailExists(
+            @RequestParam
+            @NotBlank(message = "이메일은 필수입니다.") @Email(message = "올바르지 않은 이메일 형식입니다.")
+            String email) {
+        MemberSuccessCode successCode = MemberSuccessCode.EMAIL_EXISTS_CHECK_SUCCESS;
+        MemberEmailExistsResponseDTO data = memberEmailCheckService.checkEmailExists(email);
 
-		return SuccessResponse.ok(MemberSuccessCode.EMAIL_EXISTS_CHECK_SUCCESS, data);
-	}
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.ok(successCode, data));
+    }
 
-	@GetMapping("/nickname/exists")
-	public SuccessResponse<MemberNicknameExistsResponseDTO> checkNicknameExists(
-		@RequestParam
-		@NotBlank(message = "닉네임은 필수입니다.")
-		String nickname) {
-		MemberNicknameExistsResponseDTO data = memberNicknameCheckService.checkNicknameExists(nickname);
+    @GetMapping("/nickname/exists")
+    public ResponseEntity<SuccessResponse<MemberNicknameExistsResponseDTO>> checkNicknameExists(
+            @RequestParam
+            @NotBlank(message = "닉네임은 필수입니다.")
+            String nickname) {
+        MemberSuccessCode successCode = MemberSuccessCode.NICKNAME_EXISTS_CHECK_SUCCESS;
+        MemberNicknameExistsResponseDTO data = memberNicknameCheckService.checkNicknameExists(nickname);
 
-		return SuccessResponse.ok(MemberSuccessCode.NICKNAME_EXISTS_CHECK_SUCCESS, data);
-	}
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.ok(successCode, data));
+    }
 
-	@PostMapping("/signup")
-	public SuccessResponse<MemberSignupResponseDTO> signup(
-		@Valid @RequestBody MemberSignupRequestDTO request,
-        HttpServletResponse response
-	) {
-		MemberSignupResponseDTO data = memberSignupService.signup(request, response);
+    @PostMapping("/signup")
+    public ResponseEntity<SuccessResponse<MemberSignupResponseDTO>> signup(
+            @Valid @RequestBody MemberSignupRequestDTO request,
+            HttpServletResponse response
+    ) {
+        MemberSuccessCode successCode = MemberSuccessCode.MEMBER_SIGNUP_SUCCESS;
+        MemberSignupResponseDTO data = memberSignupService.signup(request, response);
 
-		return SuccessResponse.ok(MemberSuccessCode.MEMBER_SIGNUP_SUCCESS, data);
-	}
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.ok(successCode, data));
+    }
 
-	@GetMapping("/{memberId}/profile")
-	public ResponseEntity<SuccessResponse<MemberProfileResponseDTO>> getMemberProfile(
-		@PathVariable Long memberId,
-		@RequestParam(name = "cursor", required = false) Long cursor,
-		@RequestParam(name = "limit", defaultValue = "9") int limit
-	) {
-		MemberSuccessCode successCode = MemberSuccessCode.MEMBER_PROFILE_GET_SUCCESS;
+    @GetMapping("/{memberId}/profile")
+    public ResponseEntity<SuccessResponse<MemberProfileResponseDTO>> getMemberProfile(
+            @PathVariable Long memberId,
+            @RequestParam(name = "cursor", required = false) Long cursor,
+            @RequestParam(name = "limit", defaultValue = "9") int limit
+    ) {
+        MemberSuccessCode successCode = MemberSuccessCode.MEMBER_PROFILE_GET_SUCCESS;
 
-		MemberProfileResponseDTO data = memberProfileQueryService.getMemberProfile(memberId, cursor, limit);
+        MemberProfileResponseDTO data = memberProfileQueryService.getMemberProfile(memberId, cursor, limit);
 
-		return ResponseEntity
-			.status(successCode.getStatus())
-			.body(SuccessResponse.ok(successCode, data));
-	}
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.ok(successCode, data));
+    }
 }

--- a/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package org.umc.travlocksserver.domain.member.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -59,10 +60,10 @@ public class MemberController implements MemberControllerDocs {
 
 	@PostMapping("/signup")
 	public SuccessResponse<MemberSignupResponseDTO> signup(
-		@Valid
-		@RequestBody MemberSignupRequestDTO request
+		@Valid @RequestBody MemberSignupRequestDTO request,
+        HttpServletResponse response
 	) {
-		MemberSignupResponseDTO data = memberSignupService.signup(request);
+		MemberSignupResponseDTO data = memberSignupService.signup(request, response);
 
 		return SuccessResponse.ok(MemberSuccessCode.MEMBER_SIGNUP_SUCCESS, data);
 	}

--- a/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
@@ -33,9 +33,9 @@ public interface MemberControllerDocs {
 	)
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이메일 중복 검사 성공"),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패(이메일 형식/빈 값 등)")
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패(이메일 형식/빈 값 등)", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
-	SuccessResponse<MemberEmailExistsResponseDTO> checkEmailExists(
+    ResponseEntity<SuccessResponse<MemberEmailExistsResponseDTO>> checkEmailExists(
 		@NotBlank(message = "이메일은 필수입니다.") @Email(message = "올바르지 않은 이메일 형식입니다.")
 		String email
 	);
@@ -51,9 +51,9 @@ public interface MemberControllerDocs {
 	)
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 중복 검사 성공"),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패(빈 값 등)")
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패(빈 값 등)", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
-	SuccessResponse<MemberNicknameExistsResponseDTO> checkNicknameExists(
+    ResponseEntity<SuccessResponse<MemberNicknameExistsResponseDTO>> checkNicknameExists(
 		@NotBlank(message = "닉네임은 필수입니다.")
 		String nickname
 	);
@@ -70,11 +70,11 @@ public interface MemberControllerDocs {
 	)
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공"),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / 약관 오류 / 존재하지 않는 여행 스타일·테마 ID 포함"),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패(예: signupToken 만료/불일치)"),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "충돌(예: 이메일/닉네임 중복)")
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / 약관 오류 / 존재하지 않는 여행 스타일·테마 ID 포함", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패(예: signupToken 만료/불일치)",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "충돌(예: 이메일/닉네임 중복)",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
-	SuccessResponse<MemberSignupResponseDTO> signup(
+    ResponseEntity<SuccessResponse<MemberSignupResponseDTO>> signup(
 		@Valid MemberSignupRequestDTO request,
         HttpServletResponse response
 	);

--- a/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
@@ -1,5 +1,6 @@
 package org.umc.travlocksserver.domain.member.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -64,6 +65,7 @@ public interface MemberControllerDocs {
 			            
 			- 이메일 인증 성공 후 발급된 signupToken이 필요합니다.
 			- signupToken에 매핑된 email과 요청 email이 일치해야 합니다.
+			- 회원가입 성공 시 accessToken과 refreshToken이 발급됩니다.
 			"""
 	)
 	@ApiResponses({
@@ -73,7 +75,8 @@ public interface MemberControllerDocs {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "충돌(예: 이메일/닉네임 중복)")
 	})
 	SuccessResponse<MemberSignupResponseDTO> signup(
-		@Valid MemberSignupRequestDTO request
+		@Valid MemberSignupRequestDTO request,
+        HttpServletResponse response
 	);
 
 	@Operation(

--- a/src/main/java/org/umc/travlocksserver/domain/member/dto/response/MemberSignupResponseDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/dto/response/MemberSignupResponseDTO.java
@@ -2,5 +2,8 @@ package org.umc.travlocksserver.domain.member.dto.response;
 
 public record MemberSignupResponseDTO(
         Long memberId,
-        String nickname
+        String nickname,
+        String accessToken,
+        Long accessTokenExpiresIn,
+        String profileImageUrl
 ) {}

--- a/src/main/java/org/umc/travlocksserver/domain/member/dto/response/MemberSignupResponseDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/dto/response/MemberSignupResponseDTO.java
@@ -1,9 +1,16 @@
 package org.umc.travlocksserver.domain.member.dto.response;
 
+import java.util.List;
+
 public record MemberSignupResponseDTO(
         Long memberId,
         String nickname,
         String accessToken,
         Long accessTokenExpiresIn,
-        String profileImageUrl
-) {}
+        String profileImageUrl,
+        List<PreferredThemeItem> preferredTravelThemes,
+        List<PreferredStyleItem> preferredTravelStyles
+) {
+    public record PreferredThemeItem(Long themeId, String content) {}
+    public record PreferredStyleItem(Long styleId, String content) {}
+}

--- a/src/main/java/org/umc/travlocksserver/domain/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/exception/code/MemberErrorCode.java
@@ -19,9 +19,6 @@ public enum MemberErrorCode implements BaseCode {
 	POLICY_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 약관이 포함되어 있습니다."),
 	REQUIRED_POLICY_NOT_AGREED(HttpStatus.BAD_REQUEST, "필수 약관에 동의해야 합니다."),
 
-	TRAVEL_STYLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 여행 스타일 ID가 포함되어 있습니다."),
-	TRAVEL_THEME_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 여행 테마 ID가 포함되어 있습니다."),
-
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
 
 	private final HttpStatus status;

--- a/src/main/java/org/umc/travlocksserver/domain/member/service/command/MemberSignupService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/service/command/MemberSignupService.java
@@ -18,20 +18,28 @@ import org.umc.travlocksserver.domain.member.exception.code.MemberErrorCode;
 import org.umc.travlocksserver.domain.member.repository.*;
 import org.umc.travlocksserver.domain.travelstyle.entity.PreferredTravelStyle;
 import org.umc.travlocksserver.domain.travelstyle.entity.TravelStyle;
+import org.umc.travlocksserver.domain.travelstyle.exception.TravelStyleException;
+import org.umc.travlocksserver.domain.travelstyle.exception.code.TravelStyleErrorCode;
 import org.umc.travlocksserver.domain.travelstyle.repository.PreferredTravelStyleRepository;
 import org.umc.travlocksserver.domain.travelstyle.repository.TravelStyleRepository;
 import org.umc.travlocksserver.domain.traveltheme.entity.PreferredTravelTheme;
 import org.umc.travlocksserver.domain.traveltheme.entity.TravelTheme;
+import org.umc.travlocksserver.domain.traveltheme.exception.TravelThemeException;
+import org.umc.travlocksserver.domain.traveltheme.exception.code.TravelThemeErrorCode;
 import org.umc.travlocksserver.domain.traveltheme.repository.PreferredTravelThemeRepository;
 import org.umc.travlocksserver.domain.traveltheme.repository.TravelThemeRepository;
+import org.umc.travlocksserver.global.code.BaseCode;
 import org.umc.travlocksserver.global.profile.DefaultProfileImageProvider;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class MemberSignupService {
+
+    private static final int MAX_PREFERENCES = 2;
 
     private final MemberRepository memberRepository;
     private final PolicyRepository policyRepository;
@@ -122,12 +130,32 @@ public class MemberSignupService {
 
         memberConsentRepository.saveAll(memberConsents);
 
-        // 6) 선호 스타일/테마 저장 (선택)
+        // 6) 선호 스타일/테마 저장
+        validateMax2(
+                request.preferredTravelStyleIds(),
+                TravelStyleErrorCode.TRAVEL_STYLE_MAX_EXCEEDED,
+                TravelStyleException::new
+        );
+        validateMax2(
+                request.preferredTravelThemeIds(),
+                TravelThemeErrorCode.TRAVEL_THEME_MAX_EXCEEDED,
+                TravelThemeException::new
+        );
+
+        List<MemberSignupResponseDTO.PreferredStyleItem> preferredStyles = List.of();
+        List<MemberSignupResponseDTO.PreferredThemeItem> preferredThemes = List.of();
+
         if (request.preferredTravelStyleIds() != null && !request.preferredTravelStyleIds().isEmpty()) {
-            savePreferredStyles(savedMember, request.preferredTravelStyleIds());
+            List<TravelStyle> styles = savePreferredStyles(savedMember, request.preferredTravelStyleIds());
+            preferredStyles = styles.stream()
+                    .map(s -> new MemberSignupResponseDTO.PreferredStyleItem(s.getId(), s.getContent()))
+                    .toList();
         }
         if (request.preferredTravelThemeIds() != null && !request.preferredTravelThemeIds().isEmpty()) {
-            savePreferredThemes(savedMember, request.preferredTravelThemeIds());
+            List<TravelTheme> themes = savePreferredThemes(savedMember, request.preferredTravelThemeIds());
+            preferredThemes = themes.stream()
+                    .map(t -> new MemberSignupResponseDTO.PreferredThemeItem(t.getId(), t.getContent()))
+                    .toList();
         }
 
         // 7) 회원가입 성공 시 signupToken 삭제
@@ -141,15 +169,27 @@ public class MemberSignupService {
                 savedMember.getNickname(),
                 tokens.accessToken(),
                 tokens.accessTokenExpiresIn(),
-                savedMember.getProfileImageUrl()
+                profileImageUrl,
+                preferredThemes,
+                preferredStyles
         );
     }
 
-    private void savePreferredStyles(Member member, List<Long> styleIds) {
+    private <E extends BaseCode> void validateMax2(
+            List<Long> ids,
+            E errorCode,
+            Function<E, ? extends RuntimeException> exceptionFactory
+    ) {
+        if (ids != null && ids.size() > MAX_PREFERENCES) {
+            throw exceptionFactory.apply(errorCode);
+        }
+    }
+
+    private List<TravelStyle> savePreferredStyles(Member member, List<Long> styleIds) {
         List<Long> distinct = styleIds.stream().distinct().toList();
         List<TravelStyle> styles = travelStyleRepository.findAllByIdIn(distinct);
         if (styles.size() != distinct.size()) {
-            throw new MemberException(MemberErrorCode.TRAVEL_STYLE_NOT_FOUND);
+            throw new TravelStyleException(TravelStyleErrorCode.TRAVEL_STYLE_NOT_FOUND);
         }
 
         List<PreferredTravelStyle> rows = styles.stream()
@@ -160,13 +200,14 @@ public class MemberSignupService {
                 .toList();
 
         preferredTravelStyleRepository.saveAll(rows);
+        return styles;
     }
 
-    private void savePreferredThemes(Member member, List<Long> themeIds) {
+    private List<TravelTheme> savePreferredThemes(Member member, List<Long> themeIds) {
         List<Long> distinct = themeIds.stream().distinct().toList();
         List<TravelTheme> themes = travelThemeRepository.findAllByIdIn(distinct);
         if (themes.size() != distinct.size()) {
-            throw new MemberException(MemberErrorCode.TRAVEL_THEME_NOT_FOUND);
+            throw new TravelThemeException(TravelThemeErrorCode.TRAVEL_THEME_NOT_FOUND);
         }
 
         List<PreferredTravelTheme> rows = themes.stream()
@@ -177,6 +218,7 @@ public class MemberSignupService {
                 .toList();
 
         preferredTravelThemeRepository.saveAll(rows);
+        return themes;
     }
 }
 

--- a/src/main/java/org/umc/travlocksserver/domain/member/service/command/MemberSignupService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/service/command/MemberSignupService.java
@@ -1,9 +1,11 @@
 package org.umc.travlocksserver.domain.member.service.command;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.umc.travlocksserver.domain.auth.service.command.AuthService;
 import org.umc.travlocksserver.domain.auth.service.command.SignupTokenService;
 import org.umc.travlocksserver.domain.member.dto.request.MemberSignupRequestDTO;
 import org.umc.travlocksserver.domain.member.dto.response.MemberSignupResponseDTO;
@@ -22,6 +24,7 @@ import org.umc.travlocksserver.domain.traveltheme.entity.PreferredTravelTheme;
 import org.umc.travlocksserver.domain.traveltheme.entity.TravelTheme;
 import org.umc.travlocksserver.domain.traveltheme.repository.PreferredTravelThemeRepository;
 import org.umc.travlocksserver.domain.traveltheme.repository.TravelThemeRepository;
+import org.umc.travlocksserver.global.profile.DefaultProfileImageProvider;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -33,21 +36,20 @@ public class MemberSignupService {
     private final MemberRepository memberRepository;
     private final PolicyRepository policyRepository;
     private final MemberConsentRepository memberConsentRepository;
-
     private final TravelStyleRepository travelStyleRepository;
     private final TravelThemeRepository travelThemeRepository;
     private final PreferredTravelStyleRepository preferredTravelStyleRepository;
     private final PreferredTravelThemeRepository preferredTravelThemeRepository;
-
     private final SignupTokenService signupTokenService;
     private final PasswordEncoder passwordEncoder;
+    private final AuthService authService;
+    private final DefaultProfileImageProvider defaultProfileImageProvider;
 
     @Transactional
-    public MemberSignupResponseDTO signup(MemberSignupRequestDTO request) {
+    public MemberSignupResponseDTO signup(MemberSignupRequestDTO request, HttpServletResponse response) {
 
         // 1) signupToken 검증 + 토큰에 저장된 email 조회
         String tokenEmail = signupTokenService.getEmail(request.signupToken());
-
         if (tokenEmail == null) {
             throw new MemberException(MemberErrorCode.SIGNUP_TOKEN_INVALID);
         }
@@ -92,12 +94,16 @@ public class MemberSignupService {
         }
 
         // 4) Member 생성
+        // 기본 프로필 이미지 랜덤 고정 배정
+        String profileImageUrl = defaultProfileImageProvider.pickRandomUrl();
+
         Member member = Member.builder()
                 .email(request.email())
                 .nickname(request.nickname())
                 .passwordHash(passwordEncoder.encode(request.password()))
                 .status(MemberStatus.ACTIVE)
                 .emailVerified(true)
+                .profileImageUrl(profileImageUrl)
                 .vlockCount(0)
                 .templateCount(0)
                 .starCount(0)
@@ -127,7 +133,16 @@ public class MemberSignupService {
         // 7) 회원가입 성공 시 signupToken 삭제
         signupTokenService.consume(request.signupToken());
 
-        return new MemberSignupResponseDTO(savedMember.getId(), savedMember.getNickname());
+        // AccessToken, RefreshToken 발급
+        AuthService.IssuedTokens tokens = authService.issueTokens(savedMember.getId(), response);
+
+        return new MemberSignupResponseDTO(
+                savedMember.getId(),
+                savedMember.getNickname(),
+                tokens.accessToken(),
+                tokens.accessTokenExpiresIn(),
+                savedMember.getProfileImageUrl()
+        );
     }
 
     private void savePreferredStyles(Member member, List<Long> styleIds) {

--- a/src/main/java/org/umc/travlocksserver/domain/travelstyle/exception/TravelStyleException.java
+++ b/src/main/java/org/umc/travlocksserver/domain/travelstyle/exception/TravelStyleException.java
@@ -1,0 +1,8 @@
+package org.umc.travlocksserver.domain.travelstyle.exception;
+
+import org.umc.travlocksserver.global.code.BaseCode;
+import org.umc.travlocksserver.global.exception.GeneralException;
+
+public class TravelStyleException extends GeneralException {
+    public TravelStyleException(BaseCode errorCode) { super(errorCode); }
+}

--- a/src/main/java/org/umc/travlocksserver/domain/travelstyle/exception/code/TravelStyleErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/travelstyle/exception/code/TravelStyleErrorCode.java
@@ -1,0 +1,18 @@
+package org.umc.travlocksserver.domain.travelstyle.exception.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.umc.travlocksserver.global.code.BaseCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum TravelStyleErrorCode implements BaseCode {
+
+    TRAVEL_STYLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 여행 스타일 ID가 포함되어 있습니다."),
+    TRAVEL_STYLE_MAX_EXCEEDED(HttpStatus.BAD_REQUEST, "여행 스타일은 최대 2개까지 선택할 수 있습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/org/umc/travlocksserver/domain/traveltheme/entity/TravelTheme.java
+++ b/src/main/java/org/umc/travlocksserver/domain/traveltheme/entity/TravelTheme.java
@@ -17,6 +17,6 @@ public class TravelTheme extends CreatedSoftDeleteBaseEntity {
     @Column(name = "travel_theme_id")
     private Long id;
 
-    @Column(name = "content", nullable = false, length = 10)
+    @Column(name = "content", nullable = false, length = 20)
     private String content;
 }

--- a/src/main/java/org/umc/travlocksserver/domain/traveltheme/exception/TravelThemeException.java
+++ b/src/main/java/org/umc/travlocksserver/domain/traveltheme/exception/TravelThemeException.java
@@ -1,0 +1,8 @@
+package org.umc.travlocksserver.domain.traveltheme.exception;
+
+import org.umc.travlocksserver.global.code.BaseCode;
+import org.umc.travlocksserver.global.exception.GeneralException;
+
+public class TravelThemeException extends GeneralException {
+    public TravelThemeException(BaseCode errorCode) { super(errorCode); }
+}

--- a/src/main/java/org/umc/travlocksserver/domain/traveltheme/exception/code/TravelThemeErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/traveltheme/exception/code/TravelThemeErrorCode.java
@@ -1,0 +1,18 @@
+package org.umc.travlocksserver.domain.traveltheme.exception.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.umc.travlocksserver.global.code.BaseCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum TravelThemeErrorCode implements BaseCode {
+
+    TRAVEL_THEME_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 여행 테마 ID가 포함되어 있습니다."),
+    TRAVEL_THEME_MAX_EXCEEDED(HttpStatus.BAD_REQUEST, "여행 테마는 최대 2개까지 선택할 수 있습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/org/umc/travlocksserver/global/config/PropertiesConfig.java
+++ b/src/main/java/org/umc/travlocksserver/global/config/PropertiesConfig.java
@@ -1,0 +1,9 @@
+package org.umc.travlocksserver.global.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.umc.travlocksserver.global.profile.DefaultProfileImageProperties;
+
+@Configuration
+@EnableConfigurationProperties(DefaultProfileImageProperties.class)
+public class PropertiesConfig {}

--- a/src/main/java/org/umc/travlocksserver/global/profile/DefaultProfileImageProperties.java
+++ b/src/main/java/org/umc/travlocksserver/global/profile/DefaultProfileImageProperties.java
@@ -1,0 +1,11 @@
+package org.umc.travlocksserver.global.profile;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "app.profile")
+public record DefaultProfileImageProperties(
+        String defaultBaseUrl,
+        List<String> defaultFiles
+) {}

--- a/src/main/java/org/umc/travlocksserver/global/profile/DefaultProfileImageProvider.java
+++ b/src/main/java/org/umc/travlocksserver/global/profile/DefaultProfileImageProvider.java
@@ -1,0 +1,34 @@
+package org.umc.travlocksserver.global.profile;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Component
+public class DefaultProfileImageProvider {
+
+    private final String baseUrl;
+    private final List<String> files;
+
+    public DefaultProfileImageProvider(DefaultProfileImageProperties props) {
+        this.baseUrl = normalizeBaseUrl(props.defaultBaseUrl());
+        this.files = props.defaultFiles();
+
+        if (files == null || files.isEmpty()) {
+            throw new IllegalStateException("기본 프로필 이미지 파일 목록이 비어있습니다.");
+        }
+    }
+
+    public String pickRandomUrl() {
+        int idx = ThreadLocalRandom.current().nextInt(files.size());
+        return baseUrl + "/" + files.get(idx);
+    }
+
+    private String normalizeBaseUrl(String url) {
+        if (url == null || url.isBlank()) {
+            throw new IllegalStateException("기본 프로필 이미지 base url이 비어있습니다.");
+        }
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,11 @@ jwt:
   access-ttl-seconds: ${JWT_ACCESS_TTL_SECONDS:3600} # 1시간
   refresh-ttl-seconds: ${JWT_REFRESH_TTL_SECONDS:1209600} # 14일
 
+app:
+  profile:
+    default-base-url: ${DEFAULT_PROFILE_BASE_URL:https://travlocks-bucket.s3.ap-northeast-2.amazonaws.com/profiles/defaults}
+    default-files: ${DEFAULT_PROFILE_FILES:amaze.svg,happy.svg,normal.svg,playful.svg,sad.svg,wink.png}
+
 springdoc:
   api-docs:
     enabled: true


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #52 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 회원가입 시 기본 프로필 이미지 6개 중 1개를 랜덤으로 선택하여 고정 배정하는 로직을 추가했습니다.
  - S3에 업로드된 기본 프로필 이미지 URL을 기반으로 반환하도록 구현했습니다.
- 회원가입 완료 시 Access Token과 Refresh Token을 함께 발급하도록 변경했습니다.
  - 별도의 로그인 API 호출 없이, 회원가입 직후 바로 인증된 상태로 서비스를 이용할 수 있습니다.


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
- Postman을 통해 회원가입 성공 시 응답 및 토큰 발급을 확인했습니다.  
( https://documenter.getpostman.com/view/51403325/2sBXVkAotP )
<img width="2010" height="1380" alt="image" src="https://github.com/user-attachments/assets/42073bed-0884-4e74-9d1a-c5cef605aa10" />

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.