### PR TITLE
[feat] #73 블록 삭제 API 구현

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/vlock/code/VlockErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/code/VlockErrorCode.java
@@ -15,7 +15,9 @@ public enum VlockErrorCode implements BaseCode {
 	START_VLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 출발 블록입니다."),
 	END_VLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 도착 블록입니다."),
 
-	VLOCK_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 블록에 대한 접근 권한이 없습니다.")
+	VLOCK_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 블록에 대한 접근 권한이 없습니다."),
+
+	VLOCK_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 블록입니다.")
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/code/VlockSuccessCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/code/VlockSuccessCode.java
@@ -14,7 +14,9 @@ public enum VlockSuccessCode implements BaseCode {
 
 	VLOCK_UPDATE_SUCCESS(HttpStatus.OK, "블록 수정이 완료되었습니다."),
 
-	VLOCK_GET_SUCCESS(HttpStatus.OK, "블록을 성공적으로 조회했습니다.")
+	VLOCK_GET_SUCCESS(HttpStatus.OK, "블록을 성공적으로 조회했습니다."),
+
+	VLOCK_DELETE_SUCCESS(HttpStatus.OK, "블록 삭제가 완료되었습니다.")
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -93,5 +94,18 @@ public class VlockController implements VlockControllerDocs {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(SuccessResponse.ok(VlockSuccessCode.VLOCK_UPDATE_SUCCESS, response));
+	}
+
+	/** 블록 삭제 */
+	@DeleteMapping("/{vlockId}")
+	public ResponseEntity<SuccessResponse<Void>> deleteVlock(
+		@AuthenticationPrincipal Long memberId,
+		@PathVariable Long vlockId
+	) {
+		vlockCommandService.deleteVlock(memberId, vlockId);
+
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(SuccessResponse.ok(VlockSuccessCode.VLOCK_DELETE_SUCCESS));
 	}
 }

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockControllerDocs.java
@@ -14,18 +14,20 @@ import org.umc.travlocksserver.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
+@Tag(name = "Vlock API", description = "블록 관련 API 입니다.")
 public interface VlockControllerDocs {
 
 	@Operation(
 		summary = "블록 생성",
 		description = """
-			템플릿에 사용될 블록을 생성합니다.
+		템플릿에 사용될 블록을 생성합니다.
 		
-			• 요청에 포함된 카테고리와 도시는 필수입니다.
-			• 모든 검증이 완료되면 블록이 생성됩니다.
-			• 생성된 블록을 반환합니다.
+		- 요청에 포함된 카테고리와 도시는 필수입니다.
+		- 모든 검증이 완료되면 블록이 생성됩니다.
+		- 생성된 블록을 반환합니다.
 		"""
 	)
 	@ApiResponses({
@@ -40,11 +42,11 @@ public interface VlockControllerDocs {
 	@Operation(
 		summary = "인기 블록 조회",
 		description = """
-			특정 도시의 인기 블록 목록을 조회합니다.
+		특정 도시의 인기 블록 목록을 조회합니다.
 		
-			• 이용 횟수(usageCount) 기준 내림차순
-			• 이용 횟수가 동일한 경우 최신 생성 순
-			• 최대 20개의 블록을 반환합니다.
+		- 이용 횟수(usageCount) 기준 내림차순
+		- 이용 횟수가 동일한 경우 최신 생성 순
+		- 최대 20개의 블록을 반환합니다.
 		"""
 	)
 	@ApiResponses({
@@ -57,10 +59,10 @@ public interface VlockControllerDocs {
 	@Operation(
 		summary = "카테고리 블록 조회",
 		description = """
-			특정 도시와 카테고리에 속한 블록 목록을 조회합니다.
+		특정 도시와 카테고리에 속한 블록 목록을 조회합니다.
 		
-			• 이용 횟수(usageCount) 기준 내림차순
-			• 이용 횟수가 동일한 경우 최신 생성 순으로 정렬됩니다.
+		- 이용 횟수(usageCount) 기준 내림차순
+		- 이용 횟수가 동일한 경우 최신 생성 순으로 정렬됩니다.
 		"""
 	)
 	@ApiResponses({
@@ -74,10 +76,10 @@ public interface VlockControllerDocs {
 	@Operation(
 		summary = "내가 생성한 블록 조회",
 		description = """
-			사용자가 생성한 블록 목록을 조회합니다.
+		사용자가 생성한 블록 목록을 조회합니다.
 		
-			• 특정 도시 기준으로 조회됩니다.
-			• 삭제되지 않은 블록만 반환합니다.
+		- 특정 도시 기준으로 조회됩니다.
+		- 삭제되지 않은 블록만 반환합니다.
 		"""
 	)
 	@ApiResponses({
@@ -91,11 +93,11 @@ public interface VlockControllerDocs {
 	@Operation(
 		summary = "블록 수정",
 		description = """
-			사용자가 생성한 블록의 정보를 수정합니다.
+		사용자가 생성한 블록의 정보를 수정합니다.
 		
-			• 수정 가능 항목 : 블록 이름, 주소, 카테고리, 도시, 메모, URL, 공개/비공개 여부
-			• 본인이 생성한 블록만 수정할 수 있습니다.
-			• 삭제된 블록(deletedAt != null)은 수정할 수 없습니다.
+		- 수정 가능 항목 : 블록 이름, 주소, 카테고리, 도시, 메모, URL, 공개/비공개 여부
+		- 본인이 생성한 블록만 수정할 수 있습니다.
+		- 삭제된 블록(deletedAt != null)은 수정할 수 없습니다.
 		"""
 	)
 	@ApiResponses({
@@ -113,10 +115,10 @@ public interface VlockControllerDocs {
 	@Operation(
 		summary = "블록 삭제",
 		description = """
-			사용자가 생성한 블록을 삭제합니다.
+		사용자가 생성한 블록을 삭제합니다.
 		
-			• 본인이 생성한 블록만 삭제할 수 있습니다.
-			• 이미 삭제된 블록은 다시 삭제할 수 없습니다.
+		- 본인이 생성한 블록만 삭제할 수 있습니다.
+		- 이미 삭제된 블록은 다시 삭제할 수 없습니다.
 		"""
 	)
 	@ApiResponses({

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockControllerDocs.java
@@ -21,11 +21,11 @@ public interface VlockControllerDocs {
 	@Operation(
 		summary = "블록 생성",
 		description = """
-		템플릿에 사용될 블록을 생성합니다.
+			템플릿에 사용될 블록을 생성합니다.
 		
-		• 요청에 포함된 카테고리와 도시는 필수입니다.
-		• 모든 검증이 완료되면 블록이 생성됩니다.
-		• 생성된 블록을 반환합니다.
+			• 요청에 포함된 카테고리와 도시는 필수입니다.
+			• 모든 검증이 완료되면 블록이 생성됩니다.
+			• 생성된 블록을 반환합니다.
 		"""
 	)
 	@ApiResponses({
@@ -40,11 +40,11 @@ public interface VlockControllerDocs {
 	@Operation(
 		summary = "인기 블록 조회",
 		description = """
-		특정 도시의 인기 블록 목록을 조회합니다.
+			특정 도시의 인기 블록 목록을 조회합니다.
 		
-		• 이용 횟수(usageCount) 기준 내림차순
-		• 이용 횟수가 동일한 경우 최신 생성 순
-		• 최대 20개의 블록을 반환합니다.
+			• 이용 횟수(usageCount) 기준 내림차순
+			• 이용 횟수가 동일한 경우 최신 생성 순
+			• 최대 20개의 블록을 반환합니다.
 		"""
 	)
 	@ApiResponses({
@@ -57,10 +57,10 @@ public interface VlockControllerDocs {
 	@Operation(
 		summary = "카테고리 블록 조회",
 		description = """
-		특정 도시와 카테고리에 속한 블록 목록을 조회합니다.
+			특정 도시와 카테고리에 속한 블록 목록을 조회합니다.
 		
-		• 이용 횟수(usageCount) 기준 내림차순
-		• 이용 횟수가 동일한 경우 최신 생성 순으로 정렬됩니다.
+			• 이용 횟수(usageCount) 기준 내림차순
+			• 이용 횟수가 동일한 경우 최신 생성 순으로 정렬됩니다.
 		"""
 	)
 	@ApiResponses({
@@ -74,10 +74,10 @@ public interface VlockControllerDocs {
 	@Operation(
 		summary = "내가 생성한 블록 조회",
 		description = """
-		사용자가 생성한 블록 목록을 조회합니다.
+			사용자가 생성한 블록 목록을 조회합니다.
 		
-		• 특정 도시 기준으로 조회됩니다.
-		• 삭제되지 않은 블록만 반환합니다.
+			• 특정 도시 기준으로 조회됩니다.
+			• 삭제되지 않은 블록만 반환합니다.
 		"""
 	)
 	@ApiResponses({
@@ -88,6 +88,16 @@ public interface VlockControllerDocs {
 		@AuthenticationPrincipal Long memberId,
 		@PathVariable Long cityId);
 
+	@Operation(
+		summary = "블록 수정",
+		description = """
+			사용자가 생성한 블록의 정보를 수정합니다.
+		
+			• 수정 가능 항목 : 블록 이름, 주소, 카테고리, 도시, 메모, URL, 공개/비공개 여부
+			• 본인이 생성한 블록만 수정할 수 있습니다.
+			• 삭제된 블록(deletedAt != null)은 수정할 수 없습니다.
+		"""
+	)
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "Vlock updated successfully"),
 		@ApiResponse(responseCode = "400", description = "Name, Address, Category ID, City ID is required"),
@@ -98,5 +108,25 @@ public interface VlockControllerDocs {
 		@AuthenticationPrincipal Long memberId,
 		@PathVariable Long vlockId,
 		@Valid @RequestBody VlockUpdateRequestDTO request
+	);
+
+	@Operation(
+		summary = "블록 삭제",
+		description = """
+			사용자가 생성한 블록을 삭제합니다.
+		
+			• 본인이 생성한 블록만 삭제할 수 있습니다.
+			• 이미 삭제된 블록은 다시 삭제할 수 없습니다.
+		"""
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "Vlock deleted successfully"),
+		@ApiResponse(responseCode = "400", description = "Vlock is already deleted"),
+		@ApiResponse(responseCode = "403", description = "Access to the specified vlock is forbidden"),
+		@ApiResponse(responseCode = "404", description = "Vlock ID is invalid")
+	})
+	ResponseEntity<SuccessResponse<Void>> deleteVlock(
+		@AuthenticationPrincipal Long memberId,
+		@PathVariable Long vlockId
 	);
 }

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/service/command/VlockCommandService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/service/command/VlockCommandService.java
@@ -85,6 +85,21 @@ public class VlockCommandService {
 		return VlockResponseDTO.from(vlock);
 	}
 
+	public void deleteVlock(Long memberId, Long vlockId) {
+		Vlock vlock = vlockRepository.findById(vlockId)
+			.orElseThrow(() -> new VlockException(VlockErrorCode.VLOCK_NOT_FOUND));
+
+		if (vlock.isDeleted()) {
+			throw new VlockException(VlockErrorCode.VLOCK_ALREADY_DELETED);
+		}
+
+		if (!vlock.isOwnedBy(memberId)) {
+			throw new VlockException(VlockErrorCode.VLOCK_FORBIDDEN);
+		}
+
+		vlock.softDelete();
+	}
+
     // ⚪ 외부(카카오맵) API를 통해 블록을 삽입하는 메서드 (추천시 블록에 데이터가 너무 적을 경우 사용)
     public void upsertVlocksFromExternal(Long cityId, List<KakaoPlace> places) {
         City city = cityQueryService.getReferenceById(cityId);


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #73 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 블록 삭제 API 구현
- 이미 삭제된 블록 재삭제 방어

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

[Postman Documents](https://documenter.getpostman.com/view/37268590/2sBXVmfTyr)

- 성공 케이스: 본인 블록 삭제 성공 (200) 
- 실패 케이스: 
  - Vlock이 이미 삭제된 경우 (400)
  - 타 사용자 수정 시도 → 권한 없음 (403)
  - Vlock이 존재하지 않는 경우 (404)

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.