### PR TITLE
[feat] #80 로그아웃 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 
+    // --- Jackson Java Time ---
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
     // --- Persistence & Database ---
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'

--- a/src/main/java/org/umc/travlocksserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/controller/AuthController.java
@@ -89,4 +89,16 @@ public class AuthController implements AuthControllerDocs {
                 .status(successCode.getStatus())
                 .body(SuccessResponse.ok(successCode, data));
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<SuccessResponse<?>> logout(
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        AuthSuccessCode successCode = AuthSuccessCode.AUTH_LOGOUT_SUCCESS;
+        authService.logout(request, response);
+
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.ok(successCode, null));
+    }
 }

--- a/src/main/java/org/umc/travlocksserver/domain/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/controller/AuthControllerDocs.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -20,6 +22,7 @@ import org.umc.travlocksserver.domain.auth.dto.response.AuthVerifyEmailResponseD
 import org.umc.travlocksserver.global.response.ErrorResponse;
 import org.umc.travlocksserver.global.response.SuccessResponse;
 
+@Tag(name = "Auth", description = "인증 관련 API")
 public interface AuthControllerDocs {
 
     @Operation(
@@ -32,9 +35,9 @@ public interface AuthControllerDocs {
             """
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이메일 인증 코드 발송 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / 이미 가입된 이메일 / 인증 요청 정보 오류",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "이메일 발송 실패",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "이메일 인증 코드 발송 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / 이미 가입된 이메일 / 인증 요청 정보 오류",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "이메일 발송 실패",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<SuccessResponse<AuthSendEmailResponseDTO>> sendEmailVerificationCode(
             @Valid AuthSendEmailRequestDTO request
@@ -52,8 +55,8 @@ public interface AuthControllerDocs {
             """
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이메일 인증 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / verificationId 만료·없음 / 인증 코드 불일치",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "이메일 인증 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / verificationId 만료·없음 / 인증 코드 불일치",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<SuccessResponse<AuthVerifyEmailResponseDTO>> confirmEmailVerificationCode(
             @Valid AuthVerifyEmailRequestDTO request
@@ -69,9 +72,9 @@ public interface AuthControllerDocs {
             """
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이메일 인증 코드 재발송 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / verificationId 만료·없음",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "이메일 발송 실패",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "이메일 인증 코드 재발송 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 검증 실패 / verificationId 만료·없음",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "이메일 발송 실패",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<SuccessResponse<?>> resendEmailVerificationCode(
             @Valid AuthResendEmailRequestDTO request
@@ -87,9 +90,9 @@ public interface AuthControllerDocs {
             """
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인 실패(이메일 또는 비밀번호 불일치)",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 검증 실패",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "로그인 실패(이메일 또는 비밀번호 불일치)",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<SuccessResponse<AuthLoginResponseDTO>> login(
             @Valid AuthLoginRequestDTO request,
@@ -106,10 +109,28 @@ public interface AuthControllerDocs {
             """
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "액세스 토큰 재발급 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "refreshToken 누락 / 유효하지 않음 / 만료됨",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "액세스 토큰 재발급 성공"),
+            @ApiResponse(responseCode = "400", description = "refreshToken 누락 / 유효하지 않음 / 만료됨",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<SuccessResponse<AuthRefreshResponseDTO>> refresh(
             @Parameter(hidden = true) HttpServletRequest request
+    );
+
+    @Operation(
+            summary = "로그아웃 API",
+            description = """
+            refreshToken을 무효화하고(refreshToken:{jti} Redis 삭제), 쿠키의 refreshToken을 삭제합니다.
+
+            - refreshToken은 HttpOnly 쿠키로 전달됩니다.
+            - 로그아웃은 멱등하게 동작합니다.
+              (refreshToken이 없거나 유효하지 않아도 쿠키 삭제 응답은 내려갑니다.)
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공")
+    })
+    ResponseEntity<SuccessResponse<?>> logout(
+            @Parameter(hidden = true) HttpServletRequest request,
+            @Parameter(hidden = true) HttpServletResponse response
     );
 }

--- a/src/main/java/org/umc/travlocksserver/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/exception/code/AuthErrorCode.java
@@ -9,38 +9,15 @@ import org.umc.travlocksserver.global.code.BaseCode;
 @AllArgsConstructor
 public enum AuthErrorCode implements BaseCode {
 
-    EMAIL_ALREADY_REGISTERED(
-            HttpStatus.BAD_REQUEST,
-            "이미 가입된 이메일입니다."
-    ),
-    EMAIL_SEND_FAILED(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "이메일 발송에 실패했습니다."
-    ),
-    EMAIL_VERIFICATION_NOT_FOUND(
-            HttpStatus.BAD_REQUEST,
-            "인증 요청이 만료되었거나 존재하지 않습니다."
-    ),
-    EMAIL_VERIFICATION_CODE_MISMATCH(
-            HttpStatus.BAD_REQUEST,
-            "인증 코드가 올바르지 않습니다."
-    ),
-    INVALID_SIGNUP_TOKEN(
-            HttpStatus.BAD_REQUEST,
-            "유효하지 않거나 만료된 회원가입 토큰입니다."
-    ),
-    INVALID_CREDENTIALS(
-            HttpStatus.UNAUTHORIZED,
-            "이메일 또는 비밀번호가 올바르지 않습니다."
-    ),
-    INVALID_REFRESH_TOKEN(
-            HttpStatus.BAD_REQUEST,
-            "유효하지 않거나 만료된 리프레시 토큰입니다."
-    ),
-    REFRESH_TOKEN_REQUIRED(
-            HttpStatus.BAD_REQUEST,
-            "리프레시 토큰이 필요합니다."
-    )
+    EMAIL_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 발송에 실패했습니다."),
+    EMAIL_VERIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "인증 요청이 만료되었거나 존재하지 않습니다."),
+    EMAIL_VERIFICATION_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "인증 코드가 올바르지 않습니다."),
+
+    INVALID_SIGNUP_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않거나 만료된 회원가입 토큰입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않거나 만료된 리프레시 토큰입니다."),
+    REFRESH_TOKEN_REQUIRED(HttpStatus.BAD_REQUEST, "리프레시 토큰이 필요합니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/umc/travlocksserver/domain/auth/exception/code/AuthSuccessCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/exception/code/AuthSuccessCode.java
@@ -9,21 +9,12 @@ import org.umc.travlocksserver.global.code.BaseCode;
 @AllArgsConstructor
 public enum AuthSuccessCode implements BaseCode {
 
-	EMAIL_VERIFICATION_CODE_SENT(
-		HttpStatus.OK,
-		"인증 코드가 발송되었습니다."),
-	EMAIL_VERIFICATION_CONFIRMED(
-		HttpStatus.OK,
-		"이메일 인증이 완료되었습니다."),
-	EMAIL_VERIFICATION_CODE_RESENT(
-		HttpStatus.OK,
-		"인증 코드가 재전송되었습니다."),
-    AUTH_LOGIN_SUCCESS(
-            HttpStatus.OK,
-		"로그인에 성공했습니다."),
-    AUTH_ACCESS_TOKEN_REISSUED(
-            HttpStatus.OK,
-            "액세스 토큰이 재발급되었습니다.")
+	EMAIL_VERIFICATION_CODE_SENT(HttpStatus.OK, "인증 코드가 발송되었습니다."),
+	EMAIL_VERIFICATION_CONFIRMED(HttpStatus.OK, "이메일 인증이 완료되었습니다."),
+	EMAIL_VERIFICATION_CODE_RESENT(HttpStatus.OK, "인증 코드가 재전송되었습니다."),
+    AUTH_LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
+    AUTH_ACCESS_TOKEN_REISSUED(HttpStatus.OK, "액세스 토큰이 재발급되었습니다."),
+    AUTH_LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃에 성공했습니다."),
     ;
 
 	private final HttpStatus status;

--- a/src/main/java/org/umc/travlocksserver/domain/auth/service/command/AuthService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/service/command/AuthService.java
@@ -55,37 +55,34 @@ public class AuthService {
     }
 
     public AuthRefreshResponseDTO refreshAccessToken(HttpServletRequest request) {
-
-        // 1) 쿠키에서 refreshToken 꺼내기
         String refreshToken = extractRefreshTokenFromCookie(request);
         if (refreshToken == null) {
             throw new AuthException(AuthErrorCode.REFRESH_TOKEN_REQUIRED);
         }
 
-        // 2) refreshToken 서명/만료 검증
         if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
             throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        // 3) refreshToken에서 jti 추출
+        // refreshToken에서 jti 추출
         String jti = jwtTokenProvider.extractJti(refreshToken);
         if (jti == null || jti.isBlank()) {
             throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        // 4) Redis에 jti 존재하는지 확인 (존재하면 memberId 얻음)
+        // Redis에 jti 존재하는지 확인 (존재하면 memberId 얻음)
         Long memberIdFromRedis = refreshTokenRedisRepository.findMemberId(jti);
         if (memberIdFromRedis == null) {
             throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        // 5) refreshToken 안의 sub(memberId)와 Redis 값 일치 검증
+        // refreshToken 안의 sub(memberId)와 Redis 값 일치 검증
         Long memberIdFromToken = jwtTokenProvider.extractMemberId(refreshToken);
         if (memberIdFromToken == null || !memberIdFromToken.equals(memberIdFromRedis)) {
             throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        // 6) 새 accessToken 발급
+        // 새 accessToken 발급
         String newAccessToken = jwtTokenProvider.generateAccessToken(memberIdFromRedis);
 
         return new AuthRefreshResponseDTO(
@@ -94,7 +91,13 @@ public class AuthService {
         );
     }
 
-    // AccessToken, RefreshToken 발급
+    public void logout(HttpServletRequest request, HttpServletResponse response) {
+        invalidateRefreshToken(request, response);
+    }
+
+    /**
+     * AccessToken, RefreshToken 발급
+     */
     public IssuedTokens issueTokens(Long memberId, HttpServletResponse response) {
         Duration refreshTtl = Duration.ofSeconds(refreshTtlSeconds);
 
@@ -122,6 +125,41 @@ public class AuthService {
         return new IssuedTokens(accessToken, jwtTokenProvider.getAccessTokenExpiresInSeconds());
     }
 
+    /**
+     * RefreshToken 무효화
+     */
+    public void invalidateRefreshToken(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = extractRefreshTokenFromCookie(request);
+
+        if (refreshToken != null && !refreshToken.isBlank()) {
+            try {
+                if (jwtTokenProvider.validateRefreshToken(refreshToken)) {
+                    String jti = jwtTokenProvider.extractJti(refreshToken);
+                    if (jti != null && !jti.isBlank()) {
+                        refreshTokenRedisRepository.delete(jti);
+                    }
+                }
+            } catch (Exception ignored) {
+                // 멱등 처리: 파싱/검증 오류여도 쿠키 삭제는 수행
+            }
+        }
+
+        // 쿠키 삭제
+        ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(false) // 운영환경 true
+                .path("/")
+                .maxAge(0)
+                .sameSite("Lax") // 운영환경 None
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
+    }
+
+
+    /**
+     * refreshToken 추출
+     */
     private String extractRefreshTokenFromCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies == null) return null;

--- a/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberController.java
@@ -18,10 +18,7 @@ import org.umc.travlocksserver.domain.member.service.command.MemberPasswordUpdat
 import org.umc.travlocksserver.domain.member.service.command.MemberProfileUpdateService;
 import org.umc.travlocksserver.domain.member.service.command.MemberSignupService;
 import org.umc.travlocksserver.domain.member.service.command.MemberWithdrawService;
-import org.umc.travlocksserver.domain.member.service.query.FavoriteTemplateQueryService;
-import org.umc.travlocksserver.domain.member.service.query.MemberEmailCheckService;
-import org.umc.travlocksserver.domain.member.service.query.MemberNicknameCheckService;
-import org.umc.travlocksserver.domain.member.service.query.MemberProfileQueryService;
+import org.umc.travlocksserver.domain.member.service.query.*;
 import org.umc.travlocksserver.domain.template.dto.response.TemplateCursorResponseDTO;
 import org.umc.travlocksserver.global.annotation.LoginUser;
 import org.umc.travlocksserver.global.response.SuccessResponse;
@@ -46,6 +43,7 @@ public class MemberController implements MemberControllerDocs {
     private final MemberPasswordUpdateService memberPasswordUpdateService;
     private final MemberProfileUpdateService memberProfileUpdateService;
     private final MemberWithdrawService memberWithdrawService;
+    private final MemberMyPageQueryService memberMyPageQueryService;
 
     @GetMapping("/email/exists")
     public ResponseEntity<SuccessResponse<MemberEmailExistsResponseDTO>> checkEmailExists(
@@ -109,6 +107,18 @@ public class MemberController implements MemberControllerDocs {
         MemberSuccessCode successCode = MemberSuccessCode.FAVORITE_TEMPLATE_LIST_GET_SUCCESS;
 
         TemplateCursorResponseDTO data = favoriteTemplateQueryService.getMyFavoriteTemplates(memberId, cursor, limit);
+
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(SuccessResponse.ok(successCode, data));
+    }
+
+    @GetMapping("/me/mypage")
+    public ResponseEntity<SuccessResponse<MemberMyPageResponseDTO>> getMyPage(
+            @LoginUser Member member) {
+        MemberSuccessCode successCode = MemberSuccessCode.MEMBER_MY_PAGE_RETRIEVED;
+
+        MemberMyPageResponseDTO data = memberMyPageQueryService.getMyPage(member);
 
         return ResponseEntity
                 .status(successCode.getStatus())

--- a/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
@@ -140,6 +140,28 @@ public interface MemberControllerDocs {
 	);
 
     @Operation(
+            summary = "마이페이지 조회 API",
+            description = """
+        로그인한 사용자의 마이페이지 정보를 조회합니다.
+
+        - 닉네임 / 한줄 소개
+        - 선호 여행 스타일 ID 목록
+        - 선호 여행 테마 ID 목록
+        - 내가 생성한 블록 / 템플릿 / 즐겨찾기 수
+        - 최근 생성한 블록 최대 4개
+        - 최근 생성한(=최근 사용) 템플릿 최대 4개
+        """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "마이페이지 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패(토큰 없음/만료/유효하지 않음)", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<SuccessResponse<MemberMyPageResponseDTO>> getMyPage(
+            @Parameter(hidden = true) Member member
+    );
+
+    @Operation(
             summary = "프로필 편집 API",
             description = """
         마이페이지 프로필을 편집합니다.

--- a/src/main/java/org/umc/travlocksserver/domain/member/dto/response/CreatedTemplateDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/dto/response/CreatedTemplateDTO.java
@@ -1,0 +1,11 @@
+package org.umc.travlocksserver.domain.member.dto.response;
+
+import java.time.LocalDateTime;
+
+public record CreatedTemplateDTO(
+        Long templateId,
+        String title,
+        String city,
+        LocalDateTime createdAt,
+        boolean isFavorite
+) {}

--- a/src/main/java/org/umc/travlocksserver/domain/member/dto/response/CreatedVlockDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/dto/response/CreatedVlockDTO.java
@@ -1,0 +1,11 @@
+package org.umc.travlocksserver.domain.member.dto.response;
+
+import java.time.LocalDateTime;
+
+public record CreatedVlockDTO(
+        Long vlockId,
+        String name,
+        String city,
+        LocalDateTime createdAt
+) {}
+

--- a/src/main/java/org/umc/travlocksserver/domain/member/dto/response/MemberMyPageResponseDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/dto/response/MemberMyPageResponseDTO.java
@@ -1,0 +1,24 @@
+package org.umc.travlocksserver.domain.member.dto.response;
+
+import java.util.List;
+
+public record MemberMyPageResponseDTO(
+        Long memberId,
+        String nickname,
+        String introduction,
+        List<Long> preferredTravelStyleIds,
+        List<Long> preferredTravelThemeIds,
+        Counts counts,
+        Recent recent
+) {
+    public record Counts(
+            int vlockCount,
+            int templateCount,
+            int starCount
+    ) {}
+
+    public record Recent(
+            List<CreatedVlockDTO> createdVlocks,
+            List<CreatedTemplateDTO> createdTemplates
+    ) {}
+}

--- a/src/main/java/org/umc/travlocksserver/domain/member/exception/code/MemberSuccessCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/exception/code/MemberSuccessCode.java
@@ -17,7 +17,8 @@ public enum MemberSuccessCode implements BaseCode {
     MEMBER_PASSWORD_UPDATED(HttpStatus.OK, "비밀번호가 변경되었습니다."),
     MEMBER_PROFILE_UPDATED(HttpStatus.OK, "프로필이 수정되었습니다."),
     FAVORITE_TEMPLATE_LIST_GET_SUCCESS(HttpStatus.OK, "내 즐겨찾기 목록 조회에 성공했습니다."),
-    MEMBER_WITHDRAW_SUCCESS(HttpStatus.OK, "회원 탈퇴가 완료되었습니다.")
+    MEMBER_WITHDRAW_SUCCESS(HttpStatus.OK, "회원 탈퇴가 완료되었습니다."),
+    MEMBER_MY_PAGE_RETRIEVED(HttpStatus.OK, "마이페이지 조회에 성공했습니다.")
     ;
 
 	private final HttpStatus status;

--- a/src/main/java/org/umc/travlocksserver/domain/member/service/command/MemberWithdrawService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/service/command/MemberWithdrawService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.umc.travlocksserver.domain.auth.repository.OAuthAccountRepository;
 import org.umc.travlocksserver.domain.auth.repository.RefreshTokenRedisRepository;
+import org.umc.travlocksserver.domain.auth.service.command.AuthService;
 import org.umc.travlocksserver.domain.favorite.repository.FavoriteRepository;
 import org.umc.travlocksserver.domain.member.entity.Member;
 import org.umc.travlocksserver.domain.member.entity.MemberDeletionLog;
@@ -35,13 +36,10 @@ public class MemberWithdrawService {
     private final MemberConsentRepository memberConsentRepository;
     private final FavoriteRepository starRepository;
     private final OAuthAccountRepository oAuthAccountRepository;
-
     private final VlockRepository vlockRepository;
     private final TemplateRepository templateRepository;
     private final TemplateRatingRepository templateRatingRepository;
-
-    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthService authService;
 
     @Transactional
     public void withdraw(Member loginMember, String reason, HttpServletRequest request, HttpServletResponse response) {
@@ -55,7 +53,7 @@ public class MemberWithdrawService {
                 MemberDeletionLog.create(loginMember, reason)
         );
 
-        invalidateRefreshToken(request, response);
+        authService.invalidateRefreshToken(request, response);
 
         preferredTravelStyleRepository.deleteByMemberId(memberId);
         preferredTravelThemeRepository.deleteByMemberId(memberId);
@@ -75,46 +73,6 @@ public class MemberWithdrawService {
                 anonymizedEmail(memberId),
                 anonymizedNickname(memberId)
         );
-    }
-
-    /**
-     * RefreshToken 무효화
-     */
-    private void invalidateRefreshToken(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = extractCookie(request, "refreshToken");
-
-        if (refreshToken != null && !refreshToken.isBlank()) {
-            try {
-                if (jwtTokenProvider.validateRefreshToken(refreshToken)) {
-                    String jti = jwtTokenProvider.extractJti(refreshToken);
-                    if (jti != null && !jti.isBlank()) {
-                        refreshTokenRedisRepository.delete(jti);
-                    }
-                }
-            } catch (Exception ignored) {
-            }
-        }
-
-        // 쿠키 삭제
-        ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
-                .httpOnly(true)
-                .secure(false) // 운영환경 true
-                .path("/")
-                .maxAge(0)
-                .sameSite("Lax") // 운영환경 None
-                .build();
-
-        response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
-    }
-
-    // 쿠키 추출
-    private String extractCookie(HttpServletRequest request, String name) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) return null;
-        for (Cookie cookie : cookies) {
-            if (name.equals(cookie.getName())) return cookie.getValue();
-        }
-        return null;
     }
 
     private String anonymizedEmail(Long memberId) {

--- a/src/main/java/org/umc/travlocksserver/domain/member/service/query/MemberMyPageQueryService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/service/query/MemberMyPageQueryService.java
@@ -1,0 +1,54 @@
+package org.umc.travlocksserver.domain.member.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.umc.travlocksserver.domain.member.dto.response.CreatedTemplateDTO;
+import org.umc.travlocksserver.domain.member.dto.response.CreatedVlockDTO;
+import org.umc.travlocksserver.domain.member.dto.response.MemberMyPageResponseDTO;
+import org.umc.travlocksserver.domain.member.entity.Member;
+import org.umc.travlocksserver.domain.member.exception.MemberException;
+import org.umc.travlocksserver.domain.member.exception.code.MemberErrorCode;
+import org.umc.travlocksserver.domain.member.repository.MemberRepository;
+import org.umc.travlocksserver.domain.template.repository.TemplateRepository;
+import org.umc.travlocksserver.domain.travelstyle.repository.PreferredTravelStyleRepository;
+import org.umc.travlocksserver.domain.traveltheme.repository.PreferredTravelThemeRepository;
+import org.umc.travlocksserver.domain.vlock.repository.VlockRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberMyPageQueryService {
+
+    private final MemberRepository memberRepository;
+    private final PreferredTravelStyleRepository preferredTravelStyleRepository;
+    private final PreferredTravelThemeRepository preferredTravelThemeRepository;
+    private final VlockRepository vlockRepository;
+    private final TemplateRepository templateRepository;
+
+    @Transactional(readOnly = true)
+    public MemberMyPageResponseDTO getMyPage(Member member) {
+        Long memberId = member.getId();
+
+        List<Long> styleIds = preferredTravelStyleRepository.findPreferredStyleIdsByMemberId(memberId);
+        List<Long> themeIds = preferredTravelThemeRepository.findPreferredThemeIdsByMemberId(memberId);
+
+        List<CreatedVlockDTO> vlocks = vlockRepository.findRecentCreatedVlocks(memberId, 4);
+        List<CreatedTemplateDTO> templates = templateRepository.findRecentCreatedTemplates(memberId, 4);
+
+        return new MemberMyPageResponseDTO(
+                member.getId(),
+                member.getNickname(),
+                member.getIntroduction(),
+                styleIds,
+                themeIds,
+                new MemberMyPageResponseDTO.Counts(
+                        member.getVlockCount(),
+                        member.getTemplateCount(),
+                        member.getStarCount()
+                ),
+                new MemberMyPageResponseDTO.Recent(vlocks, templates)
+        );
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.umc.travlocksserver.domain.member.dto.response.CreatedTemplateDTO;
+import org.umc.travlocksserver.domain.member.dto.response.MemberMyPageResponseDTO;
 import org.umc.travlocksserver.domain.template.entity.Template;
 
 @Repository
@@ -87,5 +89,32 @@ public interface TemplateRepository extends JpaRepository<Template, Long>, Templ
     @Query("update Template t set t.owner.id = :deletedMemberId where t.owner.id = :memberId")
     void transferOwner(@Param("memberId") Long memberId,
                        @Param("deletedMemberId") Long deletedMemberId);
+
+    @Query("""
+    select new org.umc.travlocksserver.domain.member.dto.response.CreatedTemplateDTO(
+        t.id,
+        t.title,
+        coalesce(min(c.name), ''),
+        t.createdAt,
+        case when count(f.id) > 0 then true else false end
+    )
+    from Template t
+    left join t.templateCities tc
+    left join tc.city c
+    left join Favorite f
+        on f.template.id = t.id
+       and f.member.id = :memberId
+    where t.owner.id = :memberId
+      and t.deletedAt is null
+    group by t.id, t.title, t.createdAt
+    order by t.createdAt desc, t.id desc
+    """)
+    List<CreatedTemplateDTO> findRecentCreatedTemplatesInternalwithFavorite(
+            @Param("memberId") Long memberId
+    );
+    default List<CreatedTemplateDTO> findRecentCreatedTemplates(Long memberId, int limit) {
+        List<CreatedTemplateDTO> all = findRecentCreatedTemplatesInternalwithFavorite(memberId);
+        return all.size() > limit ? all.subList(0, limit) : all;
+    }
 
 }

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/repository/VlockRepository.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/repository/VlockRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.umc.travlocksserver.domain.member.dto.response.CreatedVlockDTO;
+import org.umc.travlocksserver.domain.member.dto.response.MemberMyPageResponseDTO;
 import org.umc.travlocksserver.domain.vlock.entity.Vlock;
 
 import java.util.List;
@@ -61,4 +63,25 @@ public interface VlockRepository extends JpaRepository<Vlock,Long>, VlockReposit
     @Query("update Vlock v set v.owner.id = :deletedMemberId where v.owner.id = :memberId")
     void transferOwner(@Param("memberId") Long memberId,
                        @Param("deletedMemberId") Long deletedMemberId);
+
+    @Query("""
+    select new org.umc.travlocksserver.domain.member.dto.response.CreatedVlockDTO(
+        v.id,
+        v.name,
+        v.city.name,
+        v.createdAt
+    )
+    from Vlock v
+    where v.owner.id = :memberId
+      and v.deletedAt is null
+    order by v.createdAt desc, v.id desc
+    """)
+    List<CreatedVlockDTO> findRecentCreatedVlocksInternal(
+            @Param("memberId") Long memberId
+    );
+    default List<CreatedVlockDTO> findRecentCreatedVlocks(Long memberId, int limit) {
+        List<CreatedVlockDTO> all = findRecentCreatedVlocksInternal(memberId);
+        return all.size() > limit ? all.subList(0, limit) : all;
+    }
+
 }

--- a/src/main/java/org/umc/travlocksserver/global/config/JacksonConfig.java
+++ b/src/main/java/org/umc/travlocksserver/global/config/JacksonConfig.java
@@ -1,5 +1,7 @@
 package org.umc.travlocksserver.global.config;
 
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -9,8 +11,14 @@ import org.springframework.context.annotation.Configuration;
 public class JacksonConfig {
 
     @Bean
-    public Jackson2ObjectMapperBuilderCustomizer jsonNullableCustomizer() {
-        return builder -> builder.modules(new JsonNullableModule());
+    public Jackson2ObjectMapperBuilderCustomizer jacksonCustomizer() {
+        return builder -> {
+            builder.modules(
+                    new JsonNullableModule(),
+                    new JavaTimeModule()
+            );
+            builder.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        };
     }
 }
 

--- a/src/main/java/org/umc/travlocksserver/global/config/SecurityConfig.java
+++ b/src/main/java/org/umc/travlocksserver/global/config/SecurityConfig.java
@@ -56,7 +56,8 @@ public class SecurityConfig {
                                 "/api/v1/members/nickname/exists",
                                 "/api/v1/members/signup",
                                 "/api/v1/auth/login",
-                                "/api/v1/auth/refresh"
+                                "/api/v1/auth/refresh",
+                                "/api/v1/auth/logout"
                         ).permitAll()
 
                         // 나머지는 인증 필요

--- a/src/main/java/org/umc/travlocksserver/global/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/org/umc/travlocksserver/global/resolver/LoginUserArgumentResolver.java
@@ -2,6 +2,7 @@ package org.umc.travlocksserver.global.resolver;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -39,7 +40,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
         if (authentication == null
                 || !authentication.isAuthenticated()
                 || "anonymousUser".equals(authentication.getPrincipal())) {
-            return null;
+            throw new InsufficientAuthenticationException("Authentication required");
         }
 
         Long memberId = (Long) authentication.getPrincipal();

--- a/src/main/java/org/umc/travlocksserver/global/security/CustomAuthEntryPoint.java
+++ b/src/main/java/org/umc/travlocksserver/global/security/CustomAuthEntryPoint.java
@@ -48,9 +48,3 @@ public class CustomAuthEntryPoint implements AuthenticationEntryPoint {
         response.getWriter().write(objectMapper.writeValueAsString(new ErrorResponse(errorCode)));
     }
 }
-
-
-
-
-
-


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #80 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 로그아웃 API 구현
  - 멱등 처리
  - refreshToken이 없거나 유효하지 않아도 쿠키 삭제


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
   [Postman Documents](https://documenter.getpostman.com/view/51403325/2sBXVkAotP)
<img width="1998" height="1182" alt="image" src="https://github.com/user-attachments/assets/f0ad5021-0e15-49af-9d0f-5dca5156a897" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.