### PR TITLE
[refactor] #89 신규 도메인 도입에 따른 CORS 및 Swagger OpenAPI 설정 정리

### DIFF
--- a/src/main/java/org/umc/travlocksserver/global/config/SecurityConfig.java
+++ b/src/main/java/org/umc/travlocksserver/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package org.umc.travlocksserver.global.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -39,6 +40,7 @@ public class SecurityConfig {
 
                 // 인가 설정
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // Swagger 관련 URL 허용
                         .requestMatchers(
                                 "/swagger-ui/**",
@@ -86,16 +88,22 @@ public class SecurityConfig {
         config.setAllowCredentials(true);
         config.setAllowedOriginPatterns(List.of(
                 "http://localhost:5173",
+
+                // legacy (.kro.kr)
                 "https://travlocks.kro.kr",
+                "https://www.travlocks.kro.kr",
                 "https://api.travlocks.kro.kr",
+
+                // new (.com)
+                "https://travlocks.com",
+                "https://www.travlocks.com",
+                "https://api.travlocks.com",
+
+                // Vercel preview
                 "https://*.vercel.app"
         ));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        config.setAllowedHeaders(List.of(
-                "Authorization",
-                "Content-Type",
-                "X-Requested-With"
-        ));
+        config.addAllowedMethod("*");
+        config.addAllowedHeader("*");
 
         config.setMaxAge(3600L);
 

--- a/src/main/java/org/umc/travlocksserver/global/config/SwaggerConfig.java
+++ b/src/main/java/org/umc/travlocksserver/global/config/SwaggerConfig.java
@@ -22,7 +22,8 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(apiInfo())
                 .servers(List.of(
-                        new Server().url("https://api.travlocks.kro.kr")
+                        new Server().url("https://api.travlocks.com").description("COM"),
+                        new Server().url("https://api.travlocks.kro.kr").description("KRO (legacy)")
                 ))
                 .components(components())
                 .addSecurityItem(new SecurityRequirement().addList(JWT_SCHEME_NAME));


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #89 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- CORS 허용 Origin에 신규 도메인( travlocks.com ) 관련 도메인 추가
- SwaggerConfig OpenAPI 서버 URL에 travlocks.com 추가
- 프리플라이트 오류 대비 OPTIONS 요청 및 headers / methods 전부 허용

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

기존 도메인( travlocks.kro.kr )은 레거시 환경 유지를 위해 관련 설정을 유지하고 있습니다.