### PR TITLE
[chore] #91 Refresh Token 쿠키 설정 변경

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/auth/service/command/AuthService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/service/command/AuthService.java
@@ -114,10 +114,11 @@ public class AuthService {
         // refreshToken -> Set-Cookie
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
-                .secure(false) // 운영환경에선 true로 변경
+                .secure(true)
                 .path("/")
+                .domain(".travlocks.com")
                 .maxAge(refreshTtl)
-                .sameSite("Lax") // 운영환경에선 None으로 변경
+                .sameSite("None")
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
@@ -147,10 +148,11 @@ public class AuthService {
         // 쿠키 삭제
         ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
                 .httpOnly(true)
-                .secure(false) // 운영환경 true
+                .secure(true)
                 .path("/")
+                .domain(".travlocks.com")
                 .maxAge(0)
-                .sameSite("Lax") // 운영환경 None
+                .sameSite("None")
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #91 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 기존 Refresh Token 쿠키 옵션을 운영 환경에 맞춰
   Secure=false, SameSite=Lax → **Secure=true, SameSite=None**으로 변경

- 로그아웃 및 계정 삭제 시 쿠키 삭제가 안정적으로 동작하도록
  쿠키 도메인(.travlocks.com) 명시

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.