### PR TITLE
[feat] #96 블록 카테고리 전체 조회 API 구현

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/vlock/code/VlockCategorySuccessCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/code/VlockCategorySuccessCode.java
@@ -1,0 +1,18 @@
+package org.umc.travlocksserver.domain.vlock.code;
+
+import org.springframework.http.HttpStatus;
+import org.umc.travlocksserver.global.code.BaseCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum VlockCategorySuccessCode implements BaseCode {
+
+	DEFAULT_VLOCK_CATEGORY_GET_SUCCESS(HttpStatus.OK, "기본 블록 카테고리를 성공적으로 조회했습니다.")
+	;
+
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockCategoryController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockCategoryController.java
@@ -19,7 +19,7 @@ public class VlockCategoryController {
 
 	private final VlockCategoryQueryService vlockCategoryQueryService;
 
-	@GetMapping("/categories")
+	@GetMapping
 	public ResponseEntity<SuccessResponse<VlockCategoriesDTO>> getCategoriesVlocks() {
 		VlockCategoriesDTO responses = vlockCategoryQueryService.getAllCategories();
 

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockCategoryController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockCategoryController.java
@@ -1,0 +1,30 @@
+package org.umc.travlocksserver.domain.vlock.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.umc.travlocksserver.domain.vlock.code.VlockCategorySuccessCode;
+import org.umc.travlocksserver.domain.vlock.dto.response.VlockCategoriesDTO;
+import org.umc.travlocksserver.domain.vlock.service.query.VlockCategoryQueryService;
+import org.umc.travlocksserver.global.response.SuccessResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/vlocks/categories")
+public class VlockCategoryController {
+
+	private final VlockCategoryQueryService vlockCategoryQueryService;
+
+	@GetMapping("/categories")
+	public ResponseEntity<SuccessResponse<VlockCategoriesDTO>> getCategoriesVlocks() {
+		VlockCategoriesDTO responses = vlockCategoryQueryService.getAllCategories();
+
+		return ResponseEntity.
+			status(HttpStatus.OK)
+			.body(SuccessResponse.ok(VlockCategorySuccessCode.DEFAULT_VLOCK_CATEGORY_GET_SUCCESS, responses));
+	}
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockCategoryControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/controller/VlockCategoryControllerDocs.java
@@ -1,0 +1,29 @@
+package org.umc.travlocksserver.domain.vlock.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.umc.travlocksserver.global.response.SuccessResponse;
+import org.umc.travlocksserver.infra.redis.vlock.CachedVlockCategoryList;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Vlock Category API", description = "블록 카테고리 관련 API 입니다.")
+public interface VlockCategoryControllerDocs {
+
+	@Operation(
+		summary = "블록 카테고리 조회",
+		description = """
+		모든 카테고리 목록을 조회합니다.
+		
+		- 카테고리가 존재하지 않으면 서버 에러가 발생합니다.
+		- 카테고리 목록을 반환합니다.
+		"""
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "Vlock category retrieved successfully"),
+		@ApiResponse(responseCode = "500", description = "Default vlock category does not exist")
+	})
+	ResponseEntity<SuccessResponse<CachedVlockCategoryList>> getCategoriesVlocks();
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/dto/response/VlockCategoriesDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/dto/response/VlockCategoriesDTO.java
@@ -1,0 +1,17 @@
+package org.umc.travlocksserver.domain.vlock.dto.response;
+
+import java.util.List;
+
+import org.umc.travlocksserver.infra.redis.vlock.CachedVlockCategoryList;
+
+public record VlockCategoriesDTO(
+	List<VlockCategoryDTO> categories
+) {
+	public static VlockCategoriesDTO from(List<VlockCategoryDTO> categories) {
+		return new VlockCategoriesDTO(categories);
+	}
+
+	public static VlockCategoriesDTO fromCache(CachedVlockCategoryList cache) {
+		return new VlockCategoriesDTO(cache.categories());
+	}
+}

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/service/query/VlockCategoryQueryService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/service/query/VlockCategoryQueryService.java
@@ -1,11 +1,19 @@
 package org.umc.travlocksserver.domain.vlock.service.query;
 
+import static org.umc.travlocksserver.domain.vlock.code.VlockCategoryErrorCode.*;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.umc.travlocksserver.domain.vlock.dto.response.VlockCategoriesDTO;
+import org.umc.travlocksserver.domain.vlock.dto.response.VlockCategoryDTO;
 import org.umc.travlocksserver.domain.vlock.entity.VlockCategory;
+import org.umc.travlocksserver.domain.vlock.exception.VlockCategoryException;
 import org.umc.travlocksserver.domain.vlock.repository.VlockCategoryRepository;
+import org.umc.travlocksserver.infra.redis.vlock.CachedVlockCategoryList;
+import org.umc.travlocksserver.infra.redis.vlock.VlockCategoryCache;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -14,8 +22,29 @@ import java.util.Optional;
 public class VlockCategoryQueryService {
 
     private final VlockCategoryRepository vlockCategoryRepository;
+	private final VlockCategoryCache vlockCategoryCache;
 
     public Optional<VlockCategory> getByName(String name) {
         return vlockCategoryRepository.findByName(name);
     }
+
+	public VlockCategoriesDTO getAllCategories() {
+		CachedVlockCategoryList cachedList = vlockCategoryCache.getAll();
+
+		if (cachedList != null && !cachedList.categories().isEmpty()) {
+			return VlockCategoriesDTO.fromCache(cachedList);
+		}
+
+		List<VlockCategoryDTO> categories =  vlockCategoryRepository.findAll().stream()
+			.map(VlockCategoryDTO::from)
+			.toList();
+
+		if (categories.isEmpty()) {
+			throw new VlockCategoryException(DEFAULT_VLOCK_CATEGORY_NOT_FOUND);
+		}
+
+		vlockCategoryCache.setAll(CachedVlockCategoryList.from(categories));
+
+		return VlockCategoriesDTO.from(categories);
+	}
 }

--- a/src/main/java/org/umc/travlocksserver/infra/redis/vlock/CachedVlockCategoryList.java
+++ b/src/main/java/org/umc/travlocksserver/infra/redis/vlock/CachedVlockCategoryList.java
@@ -1,0 +1,13 @@
+package org.umc.travlocksserver.infra.redis.vlock;
+
+import java.util.List;
+
+import org.umc.travlocksserver.domain.vlock.dto.response.VlockCategoryDTO;
+
+public record CachedVlockCategoryList(
+	List<VlockCategoryDTO> categories
+) {
+	public static CachedVlockCategoryList from(List<VlockCategoryDTO> categories) {
+		return new CachedVlockCategoryList(categories);
+	}
+}

--- a/src/main/java/org/umc/travlocksserver/infra/redis/vlock/VlockCategoryCache.java
+++ b/src/main/java/org/umc/travlocksserver/infra/redis/vlock/VlockCategoryCache.java
@@ -1,0 +1,38 @@
+package org.umc.travlocksserver.infra.redis.vlock;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class VlockCategoryCache {
+
+	private final RedisTemplate<String, Object> redis;
+	private final ObjectMapper objectMapper;
+
+	@Value("${cache.categories.cache-ttl-minutes}")
+	private long ttlMinutes;
+
+	private static final String KEY = "vlock:categories:v1:all";
+
+	public CachedVlockCategoryList getAll() {
+		Object object = redis.opsForValue().get(KEY);
+
+		if (object == null) {
+			return null;
+		}
+
+		return objectMapper.convertValue(object, CachedVlockCategoryList.class);
+	}
+
+	public void setAll(CachedVlockCategoryList value) {
+		redis.opsForValue().set(KEY, value, Duration.ofMinutes(ttlMinutes));
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -102,6 +102,8 @@ cache:
       cache-ttl-minutes: 15
     vlocks:
       cache-ttl-minutes: 60
+  categories:
+    cache-ttl-minutes: 1440
 
 tmap:
   api:


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #96 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- GET /vlocks/categories 카테고리 전체 조회 API 구현
- Redis 캐싱 적용
  - 전체 카테고리 목록을 Redis에 캐시하여 반복 조회 성능 최적화
  - 캐시 미스 시 DB 조회 → 캐시 저장 흐름 구성
  - TTL 기반 만료 정책 적용

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

[Postman Documents](https://documenter.getpostman.com/view/37268590/2sBXc8p48C)

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.