### PR TITLE
[fix] #102 vlock 추천 문제 해결

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateVlockRepository.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateVlockRepository.java
@@ -25,6 +25,11 @@ public interface TemplateVlockRepository extends JpaRepository<TemplateVlock, Lo
     """)
     List<Vlock> findDistinctVlocksByTemplateDayId(@Param("templateDayId") Long templateDayId);
 
+	@Query("""
+    	SELECT tv.vlock.id
+    	FROM TemplateVlock tv
+   		WHERE tv.templateDay.template.id = :templateId
+    """)
     List<Long> findAllVlockIdsByTemplateDayTemplateId(Long templateId);
 
 	@Query("""

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/service/command/VlockCommandService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/service/command/VlockCommandService.java
@@ -136,7 +136,7 @@ public class VlockCommandService {
             default -> "기타";
         };
 
-        return vlockCategoryQueryService.getByName(name)
+        return vlockCategoryQueryService.getByName(mappedName)
                 .orElseGet(() -> vlockCategoryQueryService.getByName("기타")
                         .orElseThrow(() -> new VlockCategoryException(VlockCategoryErrorCode.DEFAULT_VLOCK_CATEGORY_NOT_FOUND)));
     }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #102

## 📌 작업 내용
> 블록 추천 로직 검토 중 문제를 발견해 해결했습니다.

1. findAllVlockIdsByTemplateDayTemplateId 메서드에 JPQL 추가
- 해당 메서드들에서 vlockId들을 반환해야하는데, JPQL 없이 JPA 메서드명 규칙으로는 TemplateVlock을 반환하게 됩니다. 
- 따라서 JPQL을 이용해 id들만 반환받도록 수정해주었습니다.

2. 카카오맵 API category 매핑 수정
- 카카오맵 API에서 받은 category를 매핑해놓고서는 매핑되지 않은 이름으로 db에 저장되는 항목들을 발견하여 수정했습니다.



## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.