### PR TITLE
[refactor] #105 Template 엔티티 컬럼 수정

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
@@ -13,11 +13,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import jakarta.validation.Valid;
-import io.swagger.v3.oas.annotations.Operation;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.umc.travlocksserver.domain.template.dto.request.TemplatePreInputRequestDTO;
 import org.umc.travlocksserver.domain.template.dto.response.TemplatePreInputResponseDTO;
+import org.umc.travlocksserver.domain.template.enums.TripDays;
 import org.umc.travlocksserver.domain.template.service.command.TemplatePreInputService;
 import org.umc.travlocksserver.domain.member.entity.Member;
 import org.umc.travlocksserver.domain.template.code.TemplateSuccessCode;
@@ -42,7 +40,6 @@ import org.umc.travlocksserver.domain.template.service.query.TemplateRouteQueryS
 import org.umc.travlocksserver.domain.template.dto.response.TemplateDetailResponseDTO;
 import org.umc.travlocksserver.global.annotation.LoginUser;
 import org.umc.travlocksserver.global.response.SuccessResponse;
-
 
 import java.util.List;
 
@@ -183,7 +180,7 @@ public class TemplateController implements TemplateControllerDocs {
 			String keyword,
 			List<String> cities,
 			List<String> themes,
-			List<String> tripDays,
+			List<TripDays> tripDays,
 			List<String> transportTypes,
 			String sort,
 			int page

--- a/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateControllerDocs.java
@@ -18,6 +18,7 @@ import org.umc.travlocksserver.domain.template.dto.response.TemplateCanvasRespon
 import org.umc.travlocksserver.domain.template.dto.response.TemplateRemixResponseDTO;
 import org.umc.travlocksserver.domain.template.enums.TransportType;
 import org.umc.travlocksserver.domain.template.dto.response.*;
+import org.umc.travlocksserver.domain.template.enums.TripDays;
 import org.umc.travlocksserver.global.response.ErrorResponse;
 import org.umc.travlocksserver.global.response.SuccessResponse;
 
@@ -28,7 +29,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 
 import org.umc.travlocksserver.domain.template.dto.response.TemplateRecommendationsDTO;
 import org.umc.travlocksserver.domain.member.entity.Member;
@@ -253,7 +253,7 @@ public interface TemplateControllerDocs {
 			@RequestParam(required = false) String keyword,
 			@RequestParam(required = false) List<String> cities,
 			@RequestParam(required = false) List<String> themes,
-			@RequestParam(required = false) List<String> tripDays,
+			@RequestParam(required = false) List<TripDays> tripDays,
 			@RequestParam(required = false) List<String> transportTypes,
 			@RequestParam(defaultValue = "별점순") String sort,
 			@RequestParam(defaultValue = "0") int page

--- a/src/main/java/org/umc/travlocksserver/domain/template/dto/request/TemplatePreInputRequestDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/dto/request/TemplatePreInputRequestDTO.java
@@ -1,11 +1,10 @@
 package org.umc.travlocksserver.domain.template.dto.request;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.umc.travlocksserver.domain.template.enums.TripDays;
 
 import java.util.List;
 
@@ -17,7 +16,7 @@ public record TemplatePreInputRequestDTO(
 
         @NotNull(message = "여행 기간 정보는 필수입니다.")
         @Valid
-        TripDTO trip,
+        TripDays tripDays,
 
         @NotEmpty(message = "교통수단은 최소 1개 이상 선택해야 합니다.")
         List<String> transportTypes,
@@ -27,14 +26,4 @@ public record TemplatePreInputRequestDTO(
         List<Long> travelThemeIds
 
 ) {
-    public record TripDTO(
-            @NotNull(message = "여행 일수는 필수입니다.")
-            @Min(value = 1, message = "여행 일수는 최소 1일입니다.")
-            @Max(value = 5, message = "여행 일수는 최대 5일입니다.")
-            Integer days,
-
-            @NotNull(message = "여행 박수는 필수입니다.")
-            @Min(value = 0, message = "여행 박수는 0 이상이어야 합니다.")
-            Integer nights
-    ) {}
 }

--- a/src/main/java/org/umc/travlocksserver/domain/template/dto/response/TemplateRecommendationCardDTO.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/dto/response/TemplateRecommendationCardDTO.java
@@ -1,6 +1,7 @@
 package org.umc.travlocksserver.domain.template.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
+import org.umc.travlocksserver.domain.template.enums.TripDays;
 
 public record TemplateRecommendationCardDTO(
         Long templateId,
@@ -13,6 +14,25 @@ public record TemplateRecommendationCardDTO(
         Double totalScore
 ) {
     @QueryProjection
-    public TemplateRecommendationCardDTO {
+    public TemplateRecommendationCardDTO(
+            Long templateId,
+            String coverImgUrl,
+            String title,
+            String description,
+            String region,
+            TripDays tripDays,
+            String tripTheme,
+            Double totalScore
+    ) {
+        this(
+                templateId,
+                coverImgUrl,
+                title,
+                description,
+                region,
+                tripDays != null ? tripDays.getDescription() : null,
+                tripTheme,
+                totalScore
+        );
     }
 }

--- a/src/main/java/org/umc/travlocksserver/domain/template/entity/Template.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/entity/Template.java
@@ -57,12 +57,6 @@ public class Template extends SoftDeleteBaseEntity {
     @Column(name = "progress_rate", nullable = false)
     private Integer progressRate = 0;
 
-    @Column(name = "start_date")
-    private LocalDate startDate;
-
-    @Column(name = "end_date")
-    private LocalDate endDate;
-
     @Column(name = "trip_days", nullable = false, length = 20)
     private String tripDays;
 
@@ -122,8 +116,6 @@ public class Template extends SoftDeleteBaseEntity {
 
 			// 초기화
 			.progressRate(0)
-			.startDate(null)
-			.endDate(null)
 			.isPublic(true)
 			.shareToken(shareToken)
 			.favoriteCount(0)

--- a/src/main/java/org/umc/travlocksserver/domain/template/entity/Template.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/entity/Template.java
@@ -4,10 +4,10 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.umc.travlocksserver.domain.member.entity.Member;
 import org.umc.travlocksserver.domain.template.enums.TransportType;
+import org.umc.travlocksserver.domain.template.enums.TripDays;
 import org.umc.travlocksserver.domain.traveltheme.entity.TravelTheme;
 import org.umc.travlocksserver.global.entity.SoftDeleteBaseEntity;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,8 +57,9 @@ public class Template extends SoftDeleteBaseEntity {
     @Column(name = "progress_rate", nullable = false)
     private Integer progressRate = 0;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "trip_days", nullable = false, length = 20)
-    private String tripDays;
+    private TripDays tripDays;
 
     @Builder.Default
     @Column(name = "vlock_count", nullable = false)

--- a/src/main/java/org/umc/travlocksserver/domain/template/enums/TripDays.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/enums/TripDays.java
@@ -1,0 +1,19 @@
+package org.umc.travlocksserver.domain.template.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TripDays {
+
+    ONE_DAY(1, "당일치기"),
+    TWO_DAYS(2, "1박 2일"),
+    THREE_DAYS(3, "2박 3일"),
+    FOUR_DAYS(4, "3박 4일"),
+    FIVE_DAYS(5, "4박 5일")
+    ;
+
+    private final int days;
+    private final String description;
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateExploreRepositoryCustom.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateExploreRepositoryCustom.java
@@ -1,6 +1,7 @@
 package org.umc.travlocksserver.domain.template.repository;
 
 import org.umc.travlocksserver.domain.template.dto.response.TemplateExploreResponseDTO;
+import org.umc.travlocksserver.domain.template.enums.TripDays;
 
 import java.util.List;
 
@@ -9,7 +10,7 @@ public interface TemplateExploreRepositoryCustom {
             String keyword,
             List<String> cityNames,
             List<String> travelThemes,
-            List<String> tripDays,
+            List<TripDays> tripDays,
             List<String> transportTypes,
             String sort,
             int offset

--- a/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateExploreRepositoryCustomImpl.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateExploreRepositoryCustomImpl.java
@@ -9,13 +9,11 @@ import org.umc.travlocksserver.domain.template.dto.response.QTemplateExploreResp
 import org.umc.travlocksserver.domain.template.entity.QTemplate;
 import org.umc.travlocksserver.domain.member.entity.QMember;
 import org.umc.travlocksserver.domain.template.enums.TransportType;
+import org.umc.travlocksserver.domain.template.enums.TripDays;
 import org.umc.travlocksserver.domain.traveltheme.entity.QTravelTheme;
 import org.umc.travlocksserver.domain.template.entity.QTemplateCity;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @Repository
 @RequiredArgsConstructor
@@ -29,7 +27,7 @@ public class TemplateExploreRepositoryCustomImpl implements TemplateExploreRepos
             String keyword,
             List<String> cityNames,
             List<String> travelThemes,
-            List<String> tripDays,
+            List<TripDays> tripDays,
             List<String> transportTypes,
             String sort,
             int offset
@@ -74,42 +72,12 @@ public class TemplateExploreRepositoryCustomImpl implements TemplateExploreRepos
                 .fetch();
     }
 
-    private com.querydsl.core.types.Predicate tripDaysIn(List<String> tripDays, QTemplate t) {
+    private com.querydsl.core.types.Predicate tripDaysIn(List<TripDays> tripDays, QTemplate t) {
         if (tripDays == null || tripDays.isEmpty()) return null;
 
-        Set<String> dbValues = new HashSet<>();
-
-        for (String front : tripDays) {
-            switch (front) {
-                case "당일치기" -> dbValues.add("당일치기");
-                case "1박 2일", "2박 3일", "3박 4일" -> dbValues.add(front);
-                case "4일 이상" -> {
-                    List<String> allTripDaysFromDB = fetchAllTripDaysFromDB();
-                    allTripDaysFromDB.stream()
-                            .filter(d -> {
-                                if (d.equals("당일치기")) return false;
-                                try {
-                                    int days = Integer.parseInt(d.split("박")[0]);
-                                    return days >= 4;
-                                } catch (Exception e) {
-                                    return false;
-                                }
-                            })
-                            .forEach(dbValues::add);
-                }
-            }
-        }
+        Set<TripDays> dbValues = new HashSet<>(tripDays);
 
         return t.tripDays.in(dbValues);
-    }
-
-    public List<String> fetchAllTripDaysFromDB() {
-        QTemplate t = QTemplate.template;
-        return queryFactory
-                .select(t.tripDays)
-                .distinct()
-                .from(t)
-                .fetch();
     }
 
     private com.querydsl.core.types.Predicate transportTypesIn(List<String> transportTypes, QTemplate t) {

--- a/src/main/java/org/umc/travlocksserver/domain/template/service/command/TemplatePreInputService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/service/command/TemplatePreInputService.java
@@ -84,8 +84,6 @@ public class TemplatePreInputService {
                 .coverImageUrl(null)  // 랜덤 이미지는 나중에 추가
                 .transportType(transportType)
                 .progressRate(0)
-                .startDate(null)
-                .endDate(null)
                 .tripDays(tripDays)
                 .vlockCount(0)
                 .isPublic(true)

--- a/src/main/java/org/umc/travlocksserver/domain/template/service/command/TemplatePreInputService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/service/command/TemplatePreInputService.java
@@ -22,8 +22,6 @@ import org.umc.travlocksserver.domain.template.repository.TemplateDayRepository;
 import org.umc.travlocksserver.domain.template.repository.TemplateRepository;
 import org.umc.travlocksserver.domain.traveltheme.entity.TravelTheme;
 import org.umc.travlocksserver.domain.traveltheme.repository.TravelThemeRepository;
-import org.umc.travlocksserver.global.exception.GeneralException;
-import org.umc.travlocksserver.global.code.ErrorCode;
 import org.umc.travlocksserver.domain.template.code.TemplateErrorCode;
 import org.umc.travlocksserver.domain.template.exception.TemplateException;
 
@@ -74,7 +72,6 @@ public class TemplatePreInputService {
 
         // 5. Template 생성
         String shareToken = UUID.randomUUID().toString();
-        String tripDays = formatTripDays(request.trip().days(), request.trip().nights());
 
         Template template = Template.builder()
                 .owner(member)
@@ -84,7 +81,7 @@ public class TemplatePreInputService {
                 .coverImageUrl(null)  // 랜덤 이미지는 나중에 추가
                 .transportType(transportType)
                 .progressRate(0)
-                .tripDays(tripDays)
+                .tripDays(request.tripDays())
                 .vlockCount(0)
                 .isPublic(true)
                 .shareToken(shareToken)
@@ -106,13 +103,14 @@ public class TemplatePreInputService {
         templateCityRepository.saveAll(templateCities);
 
         // 7. TemplateDay 생성 (days 수만큼)
-        List<TemplateDay> templateDays = createTemplateDays(savedTemplate, request.trip().days());
+        int days = request.tripDays().getDays();
+        List<TemplateDay> templateDays = createTemplateDays(savedTemplate, days);
         templateDayRepository.saveAll(templateDays);
 
         // 8. Response 반환
         return TemplatePreInputResponseDTO.of(
                 savedTemplate.getId(),
-                request.trip().days(),
+                days,
                 shareToken
         );
     }
@@ -129,15 +127,5 @@ public class TemplatePreInputService {
                         .vlockCount(0)
                         .build())
                 .toList();
-    }
-
-    /**
-     * "N박 M일" 형식 문자열 생성
-     */
-    private String formatTripDays(int days, int nights) {
-        if (nights == 0) {
-            return days + "일";  // 당일치기
-        }
-        return nights + "박 " + days + "일";
     }
 }

--- a/src/main/java/org/umc/travlocksserver/domain/template/service/command/TemplateTagService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/service/command/TemplateTagService.java
@@ -1,8 +1,6 @@
 package org.umc.travlocksserver.domain.template.service.command;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.crossstore.ChangeSetPersister;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.umc.travlocksserver.domain.location.entity.Region;
@@ -44,7 +42,7 @@ public class TemplateTagService {
 
         Region region = templateRepository.findRegionByTemplateId(templateId).get(0);
         String travelTheme = String.valueOf(template.getTravelTheme().getContent());
-        String travelDays= template.getTripDays();
+        String tripDays= template.getTripDays().getDescription();
 
         String travelTransit = switch(template.getTransportType()) {
             case WALK -> "도보";
@@ -52,7 +50,7 @@ public class TemplateTagService {
             case CAR -> "차";
         };
 
-        List<String> fixedInfoTags = List.of(travelTheme, travelDays, travelTransit);
+        List<String> fixedInfoTags = List.of(travelTheme, tripDays, travelTransit);
         List<String> cities = cityRepository.findNameByRegionId(region.getId());
 
         // AI 호출

--- a/src/main/java/org/umc/travlocksserver/domain/template/service/query/TemplateQueryService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/service/query/TemplateQueryService.java
@@ -14,6 +14,7 @@ import org.umc.travlocksserver.domain.template.dto.response.TemplateRecommendati
 import org.umc.travlocksserver.domain.template.dto.response.TemplateExploreResponseDTO;
 import org.umc.travlocksserver.domain.template.dto.response.*;
 import org.umc.travlocksserver.domain.template.entity.Template;
+import org.umc.travlocksserver.domain.template.enums.TripDays;
 import org.umc.travlocksserver.domain.template.exception.TemplateException;
 import org.umc.travlocksserver.domain.template.repository.TemplateExploreRepositoryCustom;
 import org.umc.travlocksserver.domain.template.repository.TemplateRepository;
@@ -139,7 +140,7 @@ public class TemplateQueryService {
                 template.getCoverImageUrl(),
                 template.getOwner().getId(),
                 template.getAvgRating(),
-                template.getTripDays(),
+                template.getTripDays().getDescription(),
                 template.getRemixCount(),
                 template.getDescription(),
                 tags,
@@ -152,7 +153,7 @@ public class TemplateQueryService {
             String keyword,
             List<String> cities,
             List<String> themes,
-            List<String> tripDays,
+            List<TripDays> tripDays,
             List<String> transportTypes,
             String sort,
             int page


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #105

## 📌 작업 내용
> Template 엔티티의 컬럼을 지난 전체 회의 때 수정된 내용 기반으로 변경했습니다.

### 1. start_date, end_date 컬럼 삭제

### 2. TripDays enum 생성
TripDays enum을 생성하면서 영향받은 API는 아래에 작성해두겠습니다.
Enum 생성에 따라 오류가 나는 부분 로직은 의미가 같도록 리팩토링했으며, Swagger 테스트를 통해 정상 작동 확인했습니다. 혹시 제가 놓친 부분이 있을수도 있으니, 해당 API 담당자분들이 한번 더 체크해주시면 감사하겠습니다.

### (1) GET /api/v1/templates/explore 템플릿 키워드 탐색
- tripDaysIn() 메서드가 크게 바뀌었는데, 기존 로직은 여행일수가 4일 이상(5일, 6일, ...)도 다룬다고 판단했는데, 회의 후 변경내용에 따라 여행일수가 최대 5일이어서 관련 로직은 삭제해주었습니다. 혹시 문제 있으면 알려주시면 감사하겠습니다! @Suhyeon7 

### (2) POST /api/v1/templates/pre-inputs 템플릿 사전정보 생성
- N박 M일 형태 형성하는 로직은 enum 생성에 따라 불필요하게 되어 삭제했습니다. 혹시 문제 있으면 알려주시면 감사하겠습니다! @dh2e 



## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.