### PR TITLE
[fix] #121 MemberQueryService import 경로 수정

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/member/service/query/MemberQueryService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/service/query/MemberQueryService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.umc.travlocksserver.domain.member.entity.Member;
 import org.umc.travlocksserver.domain.member.exception.MemberException;
-import org.umc.travlocksserver.domain.member.exception.code.MemberErrorCode;
+import org.umc.travlocksserver.domain.member.code.MemberErrorCode;
 import org.umc.travlocksserver.domain.member.repository.MemberRepository;
 
 @Service


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #121

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- develop 병합 이후 CI 단계에서 Gradle 컴파일이 실패
  - 원인: MemberQueryService에서 MemberErrorCode import 경로가 현재 패키지 구조와 불일치하여 package ... does not exist 에러 발생
- CI가 끊기지 않도록 MemberErrorCode import 경로를 현재 구조에 맞게 수정


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.