### PR TITLE
[fix] #125 SSE에서 @Transactional 제거

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/notification/service/command/NotificationCommandService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/notification/service/command/NotificationCommandService.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class NotificationCommandService {
 
     @Value("${sse.timeout-ms}")
@@ -84,6 +83,7 @@ public class NotificationCommandService {
     /**
      * 사용자에게 읽지 않은 알림이 있음(SSE 이벤트)을 실시간으로 푸시
      * */
+    @Transactional
     public void signalHasUnread(Long receiverId, boolean hasUnread) {
         Map<String, SseEmitter> emitters = emitterRepository.getEmitters(receiverId);
         if (emitters.isEmpty())


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #125

## 📌 작업 내용
> SSE 구독 API가 @Transactional이어서 DB Connection Pool 에러가 발생한 것으로 판단했습니다.
따라서 SSE 관련 API의 서비스 메서드에서 @Transactional을 제거해주었습니다.



## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.