### PR TITLE
[feat] #135 템플릿 삭제 API 구현

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/location/controller/RegionController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/location/controller/RegionController.java
@@ -1,4 +1,4 @@
-package org.umc.travlocksserver.domain.region.controller;
+package org.umc.travlocksserver.domain.location.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/umc/travlocksserver/domain/member/entity/Member.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/entity/Member.java
@@ -98,4 +98,7 @@ public class Member extends SoftDeleteBaseEntity {
         this.starCount = 0;
     }
 
+    public void decreaseTemplateCount() {
+        this.templateCount = this.templateCount - 1;
+    }
 }

--- a/src/main/java/org/umc/travlocksserver/domain/template/code/TemplateSuccessCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/code/TemplateSuccessCode.java
@@ -23,7 +23,8 @@ public enum TemplateSuccessCode implements BaseCode {
 	TEMPLATE_EXPLORE_SUCCESS(HttpStatus.OK,"템플릿 탐색 조회에 성공했습니다."),
 	TEMPLATE_RECENT_GET_SUCCESS(HttpStatus.OK, "최근 편집 템플릿 조회에 성공했습니다."),
 	TEMPLATE_RATING_CREATE_SUCCESS(HttpStatus.CREATED, "템플릿 평점 등록에 성공했습니다."),
-	TEMPLATE_LIST_GET_SUCCESS(HttpStatus.OK, "템플릿 리스트 조회에 성공했습니다.")
+	TEMPLATE_LIST_GET_SUCCESS(HttpStatus.OK, "템플릿 리스트 조회에 성공했습니다."),
+	TEMPLATE_DELETED_SUCCESS(HttpStatus.OK, "템플릿이 삭제되었습니다.")
 	;
 
 

--- a/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.umc.travlocksserver.domain.template.dto.request.TemplatePreInputRequestDTO;
 import org.umc.travlocksserver.domain.template.dto.response.TemplatePreInputResponseDTO;
 import org.umc.travlocksserver.domain.template.enums.TripDays;
-import org.umc.travlocksserver.domain.template.service.command.TemplatePreInputService;
+import org.umc.travlocksserver.domain.template.service.command.*;
 import org.umc.travlocksserver.domain.member.entity.Member;
 import org.umc.travlocksserver.domain.template.code.TemplateSuccessCode;
 import org.umc.travlocksserver.domain.template.dto.request.TemplateRatingCreateRequestDTO;
@@ -30,12 +30,8 @@ import org.umc.travlocksserver.domain.template.enums.TransportType;
 import org.umc.travlocksserver.domain.template.dto.response.OptimizeResponseDTO;
 import org.umc.travlocksserver.domain.template.dto.response.*;
 import org.umc.travlocksserver.domain.template.code.TemplateDaySuccessCode;
-import org.umc.travlocksserver.domain.template.service.command.TemplateDayCommandService;
 import org.umc.travlocksserver.domain.template.dto.response.VlockSuggestionsResponseDTO;
-import org.umc.travlocksserver.domain.template.service.command.TemplateRatingCommandService;
-import org.umc.travlocksserver.domain.template.service.command.TemplateRemixService;
 import org.umc.travlocksserver.domain.template.service.query.TemplateCanvasQueryService;
-import org.umc.travlocksserver.domain.template.service.command.TemplateDayOptimizeCommandService;
 import org.umc.travlocksserver.domain.template.service.query.TemplateQueryService;
 import org.umc.travlocksserver.domain.template.dto.response.PopularTemplateResponse;
 import org.umc.travlocksserver.domain.template.service.query.TemplateRouteQueryService;
@@ -64,6 +60,7 @@ public class TemplateController implements TemplateControllerDocs {
 	private final TemplateDayOptimizeCommandService templateDayOptimizeCommandService;
 	private final TemplateRouteQueryService templateRouteQueryService;
 	private final TemplateRatingCommandService templateRatingCommandService;
+	private final TemplateCommandService templateCommandService;
 
     @GetMapping("/recommendations")
     public ResponseEntity<SuccessResponse<TemplateRecommendationsDTO>> getRecommendedTemplates(
@@ -285,5 +282,16 @@ public class TemplateController implements TemplateControllerDocs {
 		return ResponseEntity
 			.status(successCode.getStatus())
 			.body(SuccessResponse.ok(successCode));
+	}
+
+	@DeleteMapping("/{templateId}")
+	public ResponseEntity<SuccessResponse<Void>> deleteTemplate(
+			@AuthenticationPrincipal Long memberId,
+			@PathVariable Long templateId
+	) {
+		templateCommandService.deleteById(memberId, templateId);
+		return ResponseEntity.ok(
+				SuccessResponse.ok(TemplateSuccessCode.TEMPLATE_DELETED_SUCCESS)
+		);
 	}
 }

--- a/src/main/java/org/umc/travlocksserver/domain/template/entity/Template.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/entity/Template.java
@@ -2,6 +2,7 @@ package org.umc.travlocksserver.domain.template.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 import org.umc.travlocksserver.domain.member.entity.Member;
 import org.umc.travlocksserver.domain.template.enums.TransportType;
 import org.umc.travlocksserver.domain.template.enums.TripDays;
@@ -11,6 +12,7 @@ import org.umc.travlocksserver.global.entity.SoftDeleteBaseEntity;
 import java.util.ArrayList;
 import java.util.List;
 
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/org/umc/travlocksserver/domain/template/service/command/TemplateCommandService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/service/command/TemplateCommandService.java
@@ -1,0 +1,26 @@
+package org.umc.travlocksserver.domain.template.service.command;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.umc.travlocksserver.domain.member.entity.Member;
+import org.umc.travlocksserver.domain.member.service.query.MemberQueryService;
+import org.umc.travlocksserver.domain.template.entity.Template;
+import org.umc.travlocksserver.domain.template.service.query.TemplateQueryService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TemplateCommandService {
+
+    private final TemplateQueryService templateQueryService;
+    private final MemberQueryService memberQueryService;
+
+    public void deleteById(Long memberId, Long templateId) {
+        Member member = memberQueryService.getById(memberId);
+        Template template = templateQueryService.getTemplateByIdAndOwnerId(templateId, memberId);
+
+        member.decreaseTemplateCount();
+        template.softDelete();
+    }
+}

--- a/src/main/java/org/umc/travlocksserver/domain/template/service/command/TemplateDayCommandService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/service/command/TemplateDayCommandService.java
@@ -552,7 +552,6 @@ public class TemplateDayCommandService {
      */
     private void fetchFromExternal(Long templateId, LatLng center, Integer radiusKm) {
         List<CityProjectionDTO> cities = templateCityQueryService.getCitiesByTemplateId(templateId);
-        log.info("템플릿 도시 추천 = {}", cities.get(0).cityName());
         if (cities.isEmpty()) return;
 
         Double x = (center == null) ? null : center.lng();


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #135

## 📌 작업 내용
>  템플릿 삭제 API를 구현했습니다.
DELETE /api/v1/templates/{templateId}

Soft Delete로 처리했으며, 삭제한 경우 해당 member의 templateCount가 -1 되도록 했습니다.
즐겨찾기, 리믹스수도 즉시 감소할지에 대해서는 PM님과 논의 후 추가할 예정입니다.



## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
<img width="492" height="159" alt="image" src="https://github.com/user-attachments/assets/24776877-dc45-40ef-8325-cebb916b4a8a" />

해당 member의 templateCount가 -1 되는 것도 확인했습니다.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.