### PR TITLE
[fix] #162 유효하지 않은 좌표 요청 시 TMAP 예외 처리

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/template/service/query/TemplateRouteQueryService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/service/query/TemplateRouteQueryService.java
@@ -103,8 +103,26 @@ public class TemplateRouteQueryService {
 		Vlock toVlock = vlockRepository.findById(toVlockId)
 			.orElseThrow(() -> new VlockException(VlockErrorCode.END_VLOCK_NOT_FOUND));
 
-		// 이동 수단에 맞는 경로 계산
-		TmapDTO.RouteInfo routeInfo = calculateRoute(fromVlock, toVlock, transportType);
+		// 좌표가 유효하지 않은 값이면(더미/범위 밖) TMAP 호출 없이 fallback
+		if (!isValidKoreaCoord(fromVlock.getLongitude(), fromVlock.getLatitude())
+			|| !isValidKoreaCoord(toVlock.getLongitude(), toVlock.getLatitude())) {
+
+			log.warn("유효하지 않은 좌표로 경로 계산 스킵: from=({}, {}), to=({}, {})",
+				fromVlock.getLongitude(), fromVlock.getLatitude(),
+				toVlock.getLongitude(), toVlock.getLatitude());
+
+			return fallbackRoute(fromVlockId, toVlockId, transportType);
+		}
+
+		// TMAP 호출 실패해도 해당 구간만 fallback
+		final TmapDTO.RouteInfo routeInfo;
+		try {
+			routeInfo = calculateRoute(fromVlock, toVlock, transportType);
+		} catch (RuntimeException e) {
+			log.warn("TMAP 경로 계산 실패 - 해당 구간만 polyline 없이 반환: {} -> {} ({}), reason={}",
+				fromVlockId, toVlockId, transportType, e.getMessage());
+			return fallbackRoute(fromVlockId, toVlockId, transportType);
+		}
 
 		MoveTime moveTime = MoveTime.builder()
 			.fromVlock(fromVlock)
@@ -118,6 +136,32 @@ public class TemplateRouteQueryService {
 		moveTimeRepository.save(moveTime);
 
 		return toResponseDTO(moveTime);
+	}
+
+	private TemplateDayRouteResponseDTO fallbackRoute(Long fromVlockId, Long toVlockId, TransportType transportType) {
+		// moveTimeId null, 시간/거리 0, polyline 좌표는 빈 배열로 반환
+		return new TemplateDayRouteResponseDTO(
+			null,
+			fromVlockId,
+			toVlockId,
+			0,
+			0,
+			transportType,
+			List.of()
+		);
+	}
+
+	/**
+	 * 한국 내 좌표 검증
+	 */
+	private boolean isValidKoreaCoord(Double lon, Double lat) {
+		if (lon == null || lat == null)
+			return false;
+		// 위경도 기본 범위
+		if (lon < -180 || lon > 180 || lat < -90 || lat > 90)
+			return false;
+		// 한국 대략 범위
+		return (lon >= 124.0 && lon <= 132.0) && (lat >= 33.0 && lat <= 39.5);
 	}
 
 	/**


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #162

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 유효하지 않은 좌표(예: 0.1) 요청 시 서버 에러 대신 빈 polyline 반환하도록 수정


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
<img width="551" height="622" alt="image" src="https://github.com/user-attachments/assets/80b8bd36-28b9-41b4-9913-5fb6aa5eed01" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.