### PR TITLE
[refactor] #166 탈퇴 계정 로그인 예외 처리

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/auth/code/AuthErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/code/AuthErrorCode.java
@@ -16,7 +16,8 @@ public enum AuthErrorCode implements BaseCode {
 
 	INVALID_SIGNUP_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않거나 만료된 회원가입 토큰입니다."),
 	INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
-	INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않거나 만료된 리프레시 토큰입니다."),
+    DELETED_ACCOUNT(HttpStatus.UNAUTHORIZED, "존재하지 않는 계정입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않거나 만료된 리프레시 토큰입니다."),
 	REFRESH_TOKEN_REQUIRED(HttpStatus.BAD_REQUEST, "리프레시 토큰이 필요합니다."),
 	PASSWORD_RESET_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "비밀번호 재설정 토큰이 올바르지 않거나 만료되었습니다."),
 	PASSWORD_RESET_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),

--- a/src/main/java/org/umc/travlocksserver/domain/auth/service/command/AuthService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/service/command/AuthService.java
@@ -16,6 +16,7 @@ import org.umc.travlocksserver.domain.auth.exception.AuthException;
 import org.umc.travlocksserver.domain.auth.code.AuthErrorCode;
 import org.umc.travlocksserver.domain.auth.repository.RefreshTokenRedisRepository;
 import org.umc.travlocksserver.domain.member.entity.Member;
+import org.umc.travlocksserver.domain.member.enums.MemberStatus;
 import org.umc.travlocksserver.domain.member.repository.MemberRepository;
 import org.umc.travlocksserver.global.jwt.JwtTokenProvider;
 
@@ -41,6 +42,10 @@ public class AuthService {
 		Member member = memberRepository.findByEmail(request.email())
 			.orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_CREDENTIALS));
 
+        if (member.getStatus() == MemberStatus.DELETED) {
+            throw new AuthException(AuthErrorCode.DELETED_ACCOUNT);
+        }
+
 		if (!member.matchesPassword(passwordEncoder, request.password())) {
 			throw new AuthException(AuthErrorCode.INVALID_CREDENTIALS);
 		}
@@ -53,6 +58,10 @@ public class AuthService {
 			tokens.accessTokenExpiresIn());
 	}
 
+
+    /**
+     * AccessToken 재발급
+     */
 	public AuthRefreshResponseDTO refreshAccessToken(HttpServletRequest request) {
 		String refreshToken = extractRefreshTokenFromCookie(request);
 		if (refreshToken == null) {

--- a/src/main/java/org/umc/travlocksserver/domain/auth/service/support/OAuthMemberFactory.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/service/support/OAuthMemberFactory.java
@@ -3,8 +3,10 @@ package org.umc.travlocksserver.domain.auth.service.support;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.umc.travlocksserver.domain.auth.code.AuthErrorCode;
 import org.umc.travlocksserver.domain.auth.entity.OAuthAccount;
 import org.umc.travlocksserver.domain.auth.enums.OAuthProvider;
+import org.umc.travlocksserver.domain.auth.exception.AuthException;
 import org.umc.travlocksserver.domain.auth.repository.OAuthAccountRepository;
 import org.umc.travlocksserver.domain.member.code.MemberErrorCode;
 import org.umc.travlocksserver.domain.member.entity.Member;
@@ -27,14 +29,25 @@ public class OAuthMemberFactory {
 		boolean emailVerified) {
 		return oauthAccountRepository.findByProviderAndProviderId(provider, providerUserId)
 			.map(OAuthAccount::getMember)
+                .map(member -> {
+                    if (member.getStatus() == MemberStatus.DELETED) {
+                        throw new AuthException(AuthErrorCode.DELETED_ACCOUNT);
+                    }
+                    return member;
+                })
 			.orElseGet(() -> createOnboardingMember(provider, providerUserId, email, emailVerified));
 	}
 
 	private Member createOnboardingMember(OAuthProvider provider, String providerUserId, String email,
 		boolean emailVerified) {
-		if (email != null && memberRepository.existsByEmail(email)) {
-			throw new MemberException(MemberErrorCode.EMAIL_ALREADY_EXISTS);
-		}
+        if (email != null && !email.isBlank()) {
+            memberRepository.findByEmail(email).ifPresent(existing -> {
+                if (existing.getStatus() == MemberStatus.DELETED) {
+                    throw new AuthException(AuthErrorCode.DELETED_ACCOUNT); // or ACCOUNT_NOT_FOUND
+                }
+                throw new MemberException(MemberErrorCode.EMAIL_ALREADY_EXISTS);
+            });
+        }
 
 		Member member = Member.builder()
 			.email(email)

--- a/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/controller/MemberControllerDocs.java
@@ -9,6 +9,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.umc.travlocksserver.domain.member.dto.request.*;
 import org.umc.travlocksserver.domain.member.dto.response.MemberEmailExistsResponseDTO;
 import org.umc.travlocksserver.domain.member.dto.response.MemberNicknameExistsResponseDTO;
@@ -149,6 +150,7 @@ public interface MemberControllerDocs {
 		@ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
 	ResponseEntity<SuccessResponse<MemberProfileUpdateResponseDTO>> updateMyProfile(
+        @Parameter(hidden = true)
 		Member member,
 		@Valid
 		MemberProfileUpdateRequestDTO request);
@@ -166,7 +168,8 @@ public interface MemberControllerDocs {
 		@ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
 	ResponseEntity<SuccessResponse<Void>> updatePassword(
-		Member member,
+        @Parameter(hidden = true)
+        Member member,
 		@Valid
 		MemberPasswordUpdateRequestDTO request);
 
@@ -185,11 +188,13 @@ public interface MemberControllerDocs {
 		@ApiResponse(responseCode = "401", description = "인증 실패(토큰 없음/만료/유효하지 않음)", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
 		@ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
-	ResponseEntity<SuccessResponse<Void>> withdraw(
-		Member member,
-		MemberWithdrawRequestDTO request,
-		HttpServletRequest httpRequest,
-		HttpServletResponse httpResponse);
+    ResponseEntity<SuccessResponse<Void>> withdraw(
+        @Parameter(hidden = true)
+        Member member,
+        @RequestBody(required = false)
+        MemberWithdrawRequestDTO request,
+        HttpServletRequest httpRequest,
+        HttpServletResponse httpResponse);
 
 	@Operation(summary = "마이페이지 내 템플릿 조회 API", description = """
 		마이페이지에서 내 템플릿 리스트를 조회하는 API입니다.

--- a/src/main/java/org/umc/travlocksserver/domain/member/entity/Member.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/entity/Member.java
@@ -87,10 +87,9 @@ public class Member extends SoftDeleteBaseEntity {
 		this.status = MemberStatus.ACTIVE;
 	}
 
-	public void withdrawAndAnonymize(String anonymizedEmail, String anonymizedNickname) {
+	public void withdrawAndAnonymize(String anonymizedNickname) {
 		this.status = MemberStatus.DELETED;
 		this.softDelete();
-		this.email = anonymizedEmail;
 		this.nickname = anonymizedNickname;
 		this.introduction = null;
 		this.passwordHash = null;

--- a/src/main/java/org/umc/travlocksserver/domain/member/service/command/MemberWithdrawService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/member/service/command/MemberWithdrawService.java
@@ -64,12 +64,7 @@ public class MemberWithdrawService {
 			.orElseThrow(() -> new IllegalStateException("회원이 존재하지 않습니다."));
 
 		member.withdrawAndAnonymize(
-			anonymizedEmail(memberId),
 			anonymizedNickname(memberId));
-	}
-
-	private String anonymizedEmail(Long memberId) {
-		return "deleted_" + memberId + "@travlocks.com";
 	}
 
 	private String anonymizedNickname(Long memberId) {


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #166 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 로그인 로직에서 탈퇴 계정을 구분하여 기존 자격 증명 오류와 다른 에러 메시지를 반환하도록 수정


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<div style="display: flex; align-items: flex-start; gap: 4%;">
  <img width="48%" src="https://github.com/user-attachments/assets/b98782d0-e9a2-4372-9a15-a1b2f2386839" />
  <img width="48%" src="https://github.com/user-attachments/assets/1dd18be8-20f6-46a7-a227-8b3fdb80667c" />
</div>




## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.