### PR TITLE
[refactor] #168 IAM Role 기반 인증으로 전환

### DIFF
--- a/src/main/java/org/umc/travlocksserver/global/aws/AwsProperties.java
+++ b/src/main/java/org/umc/travlocksserver/global/aws/AwsProperties.java
@@ -4,8 +4,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "aws")
 public record AwsProperties(
-	String region,
-	Credentials credentials) {
-	public record Credentials(String accessKey, String secretKey) {
-	}
+	String region) {
 }

--- a/src/main/java/org/umc/travlocksserver/global/aws/S3Provider.java
+++ b/src/main/java/org/umc/travlocksserver/global/aws/S3Provider.java
@@ -23,9 +23,6 @@ public class S3Provider {
 	private final S3Client s3Client;
 	private final S3Properties s3Properties;
 
-	@Value("${aws.s3.bucket}")
-	private String bucket;
-
 	public String uploadVlockFile(MultipartFile file) {
 		if (file == null || file.isEmpty()) {
 			return null;
@@ -35,7 +32,7 @@ public class S3Provider {
 
 		try {
 			PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-				.bucket(bucket)
+				.bucket(s3Properties.bucket())
 				.key(fileName)
 				.contentType(file.getContentType())
 				.build();
@@ -52,7 +49,7 @@ public class S3Provider {
 	}
 
 	public void deleteFile(String fileUrl) {
-		if (fileUrl == null || !fileUrl.contains(bucket)) {
+		if (fileUrl == null || !fileUrl.contains(s3Properties.bucket())) {
 			return;
 		}
 
@@ -60,7 +57,7 @@ public class S3Provider {
 
 		try {
 			DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
-				.bucket(bucket)
+				.bucket(s3Properties.bucket())
 				.key(key)
 				.build();
 
@@ -79,7 +76,7 @@ public class S3Provider {
 
 		try {
 			PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-				.bucket(bucket)
+				.bucket(s3Properties.bucket())
 				.key(fileName)
 				.contentType(file.getContentType())
 				.build();

--- a/src/main/java/org/umc/travlocksserver/global/config/S3Config.java
+++ b/src/main/java/org/umc/travlocksserver/global/config/S3Config.java
@@ -12,22 +12,13 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Configuration
 public class S3Config {
 
-	@Value("${aws.credentials.access-key}")
-	private String accessKey;
-
-	@Value("${aws.credentials.secret-key}")
-	private String secretKey;
-
 	@Value("${aws.region}")
 	private String region;
 
 	@Bean
 	public S3Client s3Client() {
-		AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
-
 		return S3Client.builder()
 			.region(Region.of(region))
-			.credentialsProvider(StaticCredentialsProvider.create(credentials))
 			.build();
 	}
 }

--- a/src/main/java/org/umc/travlocksserver/global/config/SecurityConfig.java
+++ b/src/main/java/org/umc/travlocksserver/global/config/SecurityConfig.java
@@ -107,12 +107,6 @@ public class SecurityConfig {
 			"http://localhost:5173",
 			"http://localhost:8080",
 
-			// legacy (.kro.kr)
-			"https://travlocks.kro.kr",
-			"https://www.travlocks.kro.kr",
-			"https://api.travlocks.kro.kr",
-
-			// new (.com)
 			"https://travlocks.com",
 			"https://www.travlocks.com",
 			"https://api.travlocks.com",

--- a/src/main/java/org/umc/travlocksserver/global/config/SwaggerConfig.java
+++ b/src/main/java/org/umc/travlocksserver/global/config/SwaggerConfig.java
@@ -23,7 +23,6 @@ public class SwaggerConfig {
 			.info(apiInfo())
 			.servers(List.of(
 				new Server().url("https://api.travlocks.com").description("COM"),
-				new Server().url("https://api.travlocks.kro.kr").description("KRO (legacy)"),
 				new Server().url("http://localhost:8080").description("LOCAL")))
 			.components(components())
 			.addSecurityItem(new SecurityRequirement().addList(JWT_SCHEME_NAME));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,9 +34,6 @@ spring:
 
 aws:
   region: ${AWS_REGION:ap-northeast-2}
-  credentials:
-    access-key: ${AWS_ACCESS_KEY_ID:}
-    secret-key: ${AWS_SECRET_ACCESS_KEY:}
   s3:
     bucket: travlocks-bucket
     domain: ${DEFAULT_S3_BASE_URL:https://travlocks-bucket.s3.ap-northeast-2.amazonaws.com/}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #168 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- CI/CD 파이프라인 구축 과정에서 생성하여 사용하던 AWS Access Key / Secret Key 제거
- EC2 IAM Role 기반 인증 구조로 전환
  - IAM Role 기반 전환 후 이미지 업로드 정상 동작 확인
- 사용하지 않는 legacy (.kro.kr) 도메인 CORS 및 Swagger 설정 제거


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.
- 로컬에서 이미지 업로드 테스트 시, .aws/credentials 파일에 AWS 자격증명을 설정해야 합니다.
   - Windows: `C:\Users\사용자\.aws\credentials`
   -  Mac/Linux: `~/.aws/credentials`             