### PR TITLE
[refactor] #172 Vlock 테이블 정합성 및 동시성 제어를 위한 externalPlaceUnique 컬럼 삽입

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/vlock/entity/Vlock.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/entity/Vlock.java
@@ -22,6 +22,14 @@ public class Vlock extends SoftDeleteBaseEntity {
 	@Column(name = "vlock_id")
 	private Long id;
 
+	// isPublic == true면 externalPlaceId, false면 NULL
+	@Column(
+			unique = true, insertable = false, updatable = false,
+			columnDefinition =
+					"VARCHAR(255) GENERATED ALWAYS AS (CASE WHEN is_public = 1 THEN external_place_id ELSE NULL END) STORED"
+	)
+	private String externalPlaceUnique;
+
 	// 외부 장소 ID(Kakao place_id 등)
 	private String externalPlaceId;
 

--- a/src/main/java/org/umc/travlocksserver/domain/vlock/service/command/VlockCommandService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/service/command/VlockCommandService.java
@@ -1,6 +1,7 @@
 package org.umc.travlocksserver.domain.vlock.service.command;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -113,20 +114,22 @@ public class VlockCommandService {
 				continue;
 			VlockCategory category = mapCategory(place.categoryName());
 
-			// 공개된 Vlock의 ExternalplaceId 기준 Vlock 조회 후 없으면 생성
-			Vlock vlock = vlockRepository.findByExternalPlaceIdAndIsPublicTrue(place.placeId())
-				.orElseGet(() -> Vlock.createByExternal(
+			try {
+				Vlock vlock = Vlock.createByExternal(
 					place.placeId(),
 					category,
 					city,
 					place.name(),
 					place.latitude(),
 					place.longitude(),
-					place.address()));
+					place.address()
+				);
 
-			vlockRepository.save(vlock);
+				vlockRepository.save(vlock);
+			} catch(DataIntegrityViolationException e) {
+				// UNIQUE 충돌 -> 이미 존재하는 블록 -> 무시
+			}
 		}
-
 	}
 
 	// ⚪ 외부(카카오맵) API를 통해 가져온 카테고리를 우리 서비스 내의 카테고리로 매핑하는 메서드


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #172

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
Vlock 테이블 정합성 및 동시성 제어를 위한 externalPlaceUnique 컬럼을 추가해주었습니다.
external_place_id, public=true 인것에만 unique 제약 조건이 걸려야하므로 별도의 컬럼을 통해 제약 설정을 해주었습니다.


## 🧪 테스트 결과
> 해당 메서드를 사용하는 '블록 추천'에서 정상적으로 조회되는 것을 확인했습니다.
<img width="572" height="490" alt="image" src="https://github.com/user-attachments/assets/3a871d05-5e32-43aa-94dd-868075f8fd53" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.