### PR TITLE
[fix] #176 findByExternalPlaceIdAndIsPublicTrue 메서드 삭제

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/vlock/repository/VlockRepository.java
+++ b/src/main/java/org/umc/travlocksserver/domain/vlock/repository/VlockRepository.java
@@ -56,8 +56,6 @@ public interface VlockRepository extends JpaRepository<Vlock, Long>, VlockReposi
 		double maxLng,
 		Pageable pageable);
 
-	Optional<Vlock> findByExternalPlaceIdAndIsPublicTrue(String externalPlaceId);
-
 	@EntityGraph(attributePaths = {"vlockCategory", "city", "city.region"})
 	List<Vlock> findAllByOwnerIdAndCityIdAndDeletedAtIsNullOrderByUsageCountDescIdDesc(Long ownerId, Long cityId);
 


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #176

## 📌 작업 내용
> 블록 추천에서 사용되지 않는 findByExternalPlaceIdAndIsPublicTrue 메서드가 호출되고 거기서 오류가 발생하고 있었습니다. 우선 해당 메서드를 아예 지워주었습니다.



## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.