### PR TITLE
[refactor] #178 소셜 로그인 이메일 충돌 전용 에러코드 분리

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/auth/code/AuthErrorCode.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/code/AuthErrorCode.java
@@ -17,6 +17,7 @@ public enum AuthErrorCode implements BaseCode {
 	INVALID_SIGNUP_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않거나 만료된 회원가입 토큰입니다."),
 	INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
     DELETED_ACCOUNT(HttpStatus.UNAUTHORIZED, "존재하지 않는 계정입니다."),
+    OAUTH_EMAIL_CONFLICT(HttpStatus.CONFLICT, "이미 이메일로 가입된 계정이 있습니다. 일반 로그인으로 로그인해주세요."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않거나 만료된 리프레시 토큰입니다."),
 	REFRESH_TOKEN_REQUIRED(HttpStatus.BAD_REQUEST, "리프레시 토큰이 필요합니다."),
 	PASSWORD_RESET_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "비밀번호 재설정 토큰이 올바르지 않거나 만료되었습니다."),

--- a/src/main/java/org/umc/travlocksserver/domain/auth/service/support/OAuthMemberFactory.java
+++ b/src/main/java/org/umc/travlocksserver/domain/auth/service/support/OAuthMemberFactory.java
@@ -45,7 +45,7 @@ public class OAuthMemberFactory {
                 if (existing.getStatus() == MemberStatus.DELETED) {
                     throw new AuthException(AuthErrorCode.DELETED_ACCOUNT); // or ACCOUNT_NOT_FOUND
                 }
-                throw new MemberException(MemberErrorCode.EMAIL_ALREADY_EXISTS);
+                throw new AuthException(AuthErrorCode.OAUTH_EMAIL_CONFLICT);
             });
         }
 


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #178

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 일반 회원가입 계정 이메일로 소셜 로그인 시도 시
  `OAUTH_EMAIL_CONFLICT` 에러를 반환하도록 로직 수정
- 기존 `EMAIL_ALREADY_REGISTERED` 에러코드와 분리하여, 소셜 로그인 전용 이메일 충돌 에러코드 `OAUTH_EMAIL_CONFLICT` 추가


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.