### PR TITLE
[refactor] #191 템플릿 리스트 조회 페이징 개선 및 totalPages 반환

### DIFF
--- a/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateController.java
@@ -3,6 +3,8 @@ package org.umc.travlocksserver.domain.template.controller;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -29,6 +31,7 @@ import org.umc.travlocksserver.domain.template.dto.response.PopularTemplateRespo
 import org.umc.travlocksserver.domain.template.service.query.TemplateRouteQueryService;
 import org.umc.travlocksserver.domain.template.dto.response.TemplateDetailResponseDTO;
 import org.umc.travlocksserver.global.annotation.LoginUser;
+import org.umc.travlocksserver.global.response.PageResponseDTO;
 import org.umc.travlocksserver.global.response.SuccessResponse;
 import org.umc.travlocksserver.domain.template.dto.request.TemplateVlockAddRequestDTO;
 import org.umc.travlocksserver.domain.template.dto.request.TemplateVlockReorderRequestDTO;
@@ -265,19 +268,22 @@ public class TemplateController implements TemplateControllerDocs {
 	}
 
 	@GetMapping("/explore")
-	public ResponseEntity<SuccessResponse<List<TemplateExploreResponseDTO>>> exploreTemplates(
+	public ResponseEntity<SuccessResponse<PageResponseDTO<TemplateExploreResponseDTO>>> exploreTemplates(
 		String keyword,
 		List<String> cities,
 		List<String> themes,
 		List<TripDays> tripDays,
 		List<String> transportTypes,
 		String sort,
-		int page) {
+		@RequestParam(defaultValue = "0") int page) {
+
+		Pageable pageable = PageRequest.of(page, 9);
+
+		PageResponseDTO<TemplateExploreResponseDTO> response = templateQueryService.exploreTemplatesWithPage(
+				keyword, cities, themes, tripDays, transportTypes, sort, pageable);
+
 		return ResponseEntity.ok(
-			SuccessResponse.ok(
-				TemplateSuccessCode.TEMPLATE_EXPLORE_SUCCESS,
-				templateQueryService.exploreTemplates(
-					keyword, cities, themes, tripDays, transportTypes, sort, page)));
+				SuccessResponse.ok(TemplateSuccessCode.TEMPLATE_EXPLORE_SUCCESS, response));
 	}
 
 	@GetMapping("/recent")

--- a/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateControllerDocs.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/controller/TemplateControllerDocs.java
@@ -19,6 +19,7 @@ import org.umc.travlocksserver.domain.template.enums.TransportType;
 import org.umc.travlocksserver.domain.template.dto.response.*;
 import org.umc.travlocksserver.domain.template.enums.TripDays;
 import org.umc.travlocksserver.global.response.ErrorResponse;
+import org.umc.travlocksserver.global.response.PageResponseDTO;
 import org.umc.travlocksserver.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.MediaType;
@@ -284,7 +285,7 @@ public interface TemplateControllerDocs {
 		""")
 	@ApiResponse(responseCode = "200", description = "템플릿 탐색 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SuccessResponse.class)))
 	@ApiResponse(responseCode = "400", description = "템플릿 탐색 실패 (잘못된 요청)", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
-	ResponseEntity<SuccessResponse<List<TemplateExploreResponseDTO>>> exploreTemplates(
+	ResponseEntity<SuccessResponse<PageResponseDTO<TemplateExploreResponseDTO>>> exploreTemplates(
 		@RequestParam(required = false)
 		String keyword,
 		@RequestParam(required = false)

--- a/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateExploreRepositoryCustom.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateExploreRepositoryCustom.java
@@ -1,17 +1,19 @@
 package org.umc.travlocksserver.domain.template.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.umc.travlocksserver.domain.template.dto.response.TemplateExploreResponseDTO;
 import org.umc.travlocksserver.domain.template.enums.TripDays;
 
 import java.util.List;
 
 public interface TemplateExploreRepositoryCustom {
-	List<TemplateExploreResponseDTO> findExploreTemplates(
+	Page<TemplateExploreResponseDTO> findExploreTemplatesWithPage(
 		String keyword,
 		List<String> cityNames,
 		List<String> travelThemes,
 		List<TripDays> tripDays,
 		List<String> transportTypes,
 		String sort,
-		int offset);
+		Pageable pageable);
 }

--- a/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateExploreRepositoryCustomImpl.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/repository/TemplateExploreRepositoryCustomImpl.java
@@ -4,6 +4,8 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.umc.travlocksserver.domain.template.dto.response.TemplateExploreResponseDTO;
 import org.umc.travlocksserver.domain.template.dto.response.QTemplateExploreResponseDTO;
@@ -24,14 +26,14 @@ public class TemplateExploreRepositoryCustomImpl implements TemplateExploreRepos
 	private static final int PAGE_SIZE = 9; // 한 페이지당 9개로 고정
 
 	@Override
-	public List<TemplateExploreResponseDTO> findExploreTemplates(
+	public Page<TemplateExploreResponseDTO> findExploreTemplatesWithPage(
 		String keyword,
 		List<String> cityNames,
 		List<String> travelThemes,
 		List<TripDays> tripDays,
 		List<String> transportTypes,
 		String sort,
-		int offset) {
+		Pageable pageable) {
 		QTemplate t = QTemplate.template;
 		QMember m = QMember.member;
 		QTravelTheme tt = QTravelTheme.travelTheme;
@@ -41,7 +43,7 @@ public class TemplateExploreRepositoryCustomImpl implements TemplateExploreRepos
 		OrderSpecifier<?> orderSpecifier = getOrderSpecifier(t, sort);
 
 		// QueryDSL 쿼리 작성
-		return queryFactory
+		var query = queryFactory
 			.select(
 				new QTemplateExploreResponseDTO(
 					t.id,
@@ -63,10 +65,16 @@ public class TemplateExploreRepositoryCustomImpl implements TemplateExploreRepos
 				travelThemesIn(travelThemes, tt),
 				tripDaysIn(tripDays, t),
 				transportTypesIn(transportTypes, t))
-			.offset(offset)
-			.limit(PAGE_SIZE)
-			.orderBy(orderSpecifier)
-			.fetch();
+			.offset((pageable.getOffset()))
+			.limit(pageable.getPageSize())
+			.orderBy(orderSpecifier);
+
+		var results = query.fetchResults();
+
+		return new org.springframework.data.domain.PageImpl<>(
+				results.getResults(),
+				pageable,
+				results.getTotal());
 	}
 
 	private com.querydsl.core.types.Predicate tripDaysIn(List<TripDays> tripDays, QTemplate t) {

--- a/src/main/java/org/umc/travlocksserver/domain/template/service/query/TemplateQueryService.java
+++ b/src/main/java/org/umc/travlocksserver/domain/template/service/query/TemplateQueryService.java
@@ -3,7 +3,9 @@ package org.umc.travlocksserver.domain.template.service.query;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.umc.travlocksserver.domain.favorite.repository.FavoriteRepository;
@@ -20,6 +22,7 @@ import org.umc.travlocksserver.domain.template.exception.TemplateException;
 import org.umc.travlocksserver.domain.template.repository.TemplateExploreRepositoryCustom;
 import org.umc.travlocksserver.domain.template.repository.TemplateRepository;
 import org.umc.travlocksserver.domain.traveltheme.repository.PreferredTravelThemeRepository;
+import org.umc.travlocksserver.global.response.PageResponseDTO;
 import org.umc.travlocksserver.infra.redis.template.CachedTemplateSuggestions;
 import org.umc.travlocksserver.infra.redis.template.TemplateSuggestionCache;
 
@@ -150,29 +153,23 @@ public class TemplateQueryService {
 			isFavorited);
 	}
 
-	public List<TemplateExploreResponseDTO> exploreTemplates(
+	public PageResponseDTO<TemplateExploreResponseDTO> exploreTemplatesWithPage(
 		String keyword,
 		List<String> cities,
 		List<String> themes,
 		List<TripDays> tripDays,
 		List<String> transportTypes,
 		String sort,
-		int page) {
+		Pageable pageable) {
 
-		List<TemplateExploreResponseDTO> result = templateExploreRepositoryCustom.findExploreTemplates(
-			keyword,
-			cities,
-			themes,
-			tripDays,
-			transportTypes,
-			sort,
-			page * 9);
+		Page<TemplateExploreResponseDTO> result = templateExploreRepositoryCustom.findExploreTemplatesWithPage(
+				keyword, cities, themes, tripDays, transportTypes, sort, pageable);
 
 		if (result.isEmpty()) {
 			throw new TemplateException(TemplateErrorCode.TEMPLATE_NO_MATCH);
 		}
 
-		return result;
+		return PageResponseDTO.from(result);
 	}
 
 	public List<TemplateLatestDTO> getRecentTemplates(Long memberId) {


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #191

## 📌 작업 내용
> /explore API에서 현재 리스트만 반환되는 구조를, PageResponseDTO를 활용한 페이징 응답 구조로 변경



## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.
<img width="680" height="368" alt="스크린샷 2026-02-19 오후 10 27 19" src="https://github.com/user-attachments/assets/7c562bc3-8a4f-4aa3-b0a0-e3381420778d" />



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.